### PR TITLE
Simplify redstone BPE patch

### DIFF
--- a/PaperSpigot-Server-Patches/0017-Add-option-to-stop-redstone-firing-BlockPhysicsEvent.patch
+++ b/PaperSpigot-Server-Patches/0017-Add-option-to-stop-redstone-firing-BlockPhysicsEvent.patch
@@ -14,8 +14,7 @@ index 1bb15b6..8fa41d9 100644
                  CraftWorld world = ((WorldServer) this).getWorld();
 -                if (world != null) {
 +				// TacoSpigot start - Add config to disable redstone firing BlockPhysicsEvent 
-+				boolean isRedstone = block instanceof BlockRedstoneWire || block instanceof BlockRedstoneTorch;
-+				boolean dispatchBPE = isRedstone && !this.tacoSpigotConfig.isRedstoneFireBPE? false : true;
++				boolean dispatchBPE = this.tacoSpigotConfig.isRedstoneFireBPE? true : !(block instanceof BlockRedstoneWire || block instanceof BlockRedstoneTorch);
 +                if (world != null && dispatchBPE) {
 +				// TacoSpigot end
                      BlockPhysicsEvent event = new BlockPhysicsEvent(world.getBlockAt(blockposition.getX(), blockposition.getY(), blockposition.getZ()), CraftMagicNumbers.getId(block));


### PR DESCRIPTION
This seems to make more sense, and we're only instantiating one boolean instead of two. I haven't benchmarked it, but it could add up considering how frequently this method is called. (hundreds of times / second on larger survival-based gamemodes)