### PR TITLE
optimize tnt entity and falling block movements

### DIFF
--- a/PaperSpigot-Server-Patches/0024-optimize-tnt-entity-and-falling-block-movement.patch
+++ b/PaperSpigot-Server-Patches/0024-optimize-tnt-entity-and-falling-block-movement.patch
@@ -1,31 +1,35 @@
-From af5960c7f755434cd20925c847d208a39a9ed099 Mon Sep 17 00:00:00 2001
+From 5440c9d1faabd484cb095bb870bca72cf8c79264 Mon Sep 17 00:00:00 2001
 From: nirmal <upwardshybriding@gmail.com>
 Date: Wed, 29 Nov 2017 22:14:32 -0500
 Subject: [PATCH] optimize tnt entity and falling block movement
 
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 2da303f..884eca8 100644
+index 2da303fe..e8084db5 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
-@@ -515,7 +515,15 @@ public abstract class Entity implements ICommandListener {
+@@ -515,7 +515,19 @@ public abstract class Entity implements ICommandListener {
                  }
              }
  
 -            List list = this.world.getCubes(this, this.getBoundingBox().a(d0, d1, d2));
-+            boolean axisScan = d0 * d1 * d2 > 25; // TacoSpigot - do axis by axis scan if the entity is travelling a large area
++            AxisAlignedBB totalArea = this.getBoundingBox().a(d0, d1, d2);
++            double xLength = totalArea.d - totalArea.a;
++            double yLength = totalArea.e - totalArea.b;
++            double zLength = totalArea.f - totalArea.c;
++            boolean axisScan = xLength * yLength * zLength > 10; // TacoSpigot - do axis by axis scan if the entity is travelling a large area
 +
 +            List list;
 +            if(axisScan) {
 +                list = this.world.getCubes(this, this.getBoundingBox().a(0, d1, 0)); // TacoSpigot - get y axis blocks
 +            } else {
-+                list = this.world.getCubes(this, this.getBoundingBox().a(d0, d1, d2));
++                list = this.world.getCubes(this, totalArea);
 +            }
 +
              AxisAlignedBB axisalignedbb = this.getBoundingBox();
  
              AxisAlignedBB axisalignedbb1;
-@@ -527,6 +535,10 @@ public abstract class Entity implements ICommandListener {
+@@ -527,6 +539,10 @@ public abstract class Entity implements ICommandListener {
              this.a(this.getBoundingBox().c(0.0D, d1, 0.0D));
              boolean flag1 = this.onGround || d7 != d1 && d7 < 0.0D;
  
@@ -36,7 +40,7 @@ index 2da303f..884eca8 100644
              AxisAlignedBB axisalignedbb2;
              Iterator iterator1;
  
-@@ -536,6 +548,10 @@ public abstract class Entity implements ICommandListener {
+@@ -536,6 +552,10 @@ public abstract class Entity implements ICommandListener {
  
              this.a(this.getBoundingBox().c(d0, 0.0D, 0.0D));
  
@@ -48,7 +52,7 @@ index 2da303f..884eca8 100644
                  axisalignedbb2 = (AxisAlignedBB) iterator1.next();
              }
 diff --git a/src/main/java/net/minecraft/server/Explosion.java b/src/main/java/net/minecraft/server/Explosion.java
-index b7d410e..5c0219b 100644
+index b7d410ee..5c0219b7 100644
 --- a/src/main/java/net/minecraft/server/Explosion.java
 +++ b/src/main/java/net/minecraft/server/Explosion.java
 @@ -54,40 +54,44 @@ public class Explosion {
@@ -130,7 +134,7 @@ index b7d410e..5c0219b 100644
                      }
                  }
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 22e39bd..d4f337e 100644
+index 22e39bd8..d4f337e2 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -1233,6 +1233,8 @@ public abstract class World implements IBlockAccess {
@@ -143,5 +147,5 @@ index 22e39bd..d4f337e 100644
          double d0 = 0.25D;
          List list = this.getEntities(entity, axisalignedbb.grow(d0, d0, d0));
 -- 
-2.7.4
+2.14.2.windows.3
 

--- a/PaperSpigot-Server-Patches/0024-optimize-tnt-entity-and-falling-block-movement.patch
+++ b/PaperSpigot-Server-Patches/0024-optimize-tnt-entity-and-falling-block-movement.patch
@@ -1,0 +1,135 @@
+From b6b625a5bb4aeffd73c1559275af4695e711dc2b Mon Sep 17 00:00:00 2001
+From: nirmal <upwardshybriding@gmail.com>
+Date: Wed, 29 Nov 2017 22:14:32 -0500
+Subject: [PATCH] optimize tnt entity and falling block movement
+
+
+diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
+index 2da303f..b32ffa9 100644
+--- a/src/main/java/net/minecraft/server/Entity.java
++++ b/src/main/java/net/minecraft/server/Entity.java
+@@ -515,7 +515,7 @@ public abstract class Entity implements ICommandListener {
+                 }
+             }
+ 
+-            List list = this.world.getCubes(this, this.getBoundingBox().a(d0, d1, d2));
++            List list = this.world.getCubes(this, this.getBoundingBox().a(0, d1, 0)); // TacoSpigot - get y axis blocks
+             AxisAlignedBB axisalignedbb = this.getBoundingBox();
+ 
+             AxisAlignedBB axisalignedbb1;
+@@ -527,6 +527,8 @@ public abstract class Entity implements ICommandListener {
+             this.a(this.getBoundingBox().c(0.0D, d1, 0.0D));
+             boolean flag1 = this.onGround || d7 != d1 && d7 < 0.0D;
+ 
++            list = this.world.getCubes(this, this.getBoundingBox().a(d0, 0, 0)); // TacoSpigot - get x axis blocks
++
+             AxisAlignedBB axisalignedbb2;
+             Iterator iterator1;
+ 
+@@ -536,6 +538,8 @@ public abstract class Entity implements ICommandListener {
+ 
+             this.a(this.getBoundingBox().c(d0, 0.0D, 0.0D));
+ 
++            list = this.world.getCubes(this, this.getBoundingBox().a(0, 0, d2)); // TacoSpigot - get z axis blocks
++
+             for (iterator1 = list.iterator(); iterator1.hasNext(); d2 = axisalignedbb2.c(this.getBoundingBox(), d2)) {
+                 axisalignedbb2 = (AxisAlignedBB) iterator1.next();
+             }
+diff --git a/src/main/java/net/minecraft/server/Explosion.java b/src/main/java/net/minecraft/server/Explosion.java
+index b7d410e..5c0219b 100644
+--- a/src/main/java/net/minecraft/server/Explosion.java
++++ b/src/main/java/net/minecraft/server/Explosion.java
+@@ -54,40 +54,44 @@ public class Explosion {
+         int i;
+         int j;
+ 
+-        for (int k = 0; k < 16; ++k) {
+-            for (i = 0; i < 16; ++i) {
+-                for (j = 0; j < 16; ++j) {
+-                    if (k == 0 || k == 15 || i == 0 || i == 15 || j == 0 || j == 15) {
+-                        double d0 = (double) ((float) k / 15.0F * 2.0F - 1.0F);
+-                        double d1 = (double) ((float) i / 15.0F * 2.0F - 1.0F);
+-                        double d2 = (double) ((float) j / 15.0F * 2.0F - 1.0F);
+-                        double d3 = Math.sqrt(d0 * d0 + d1 * d1 + d2 * d2);
+-
+-                        d0 /= d3;
+-                        d1 /= d3;
+-                        d2 /= d3;
+-                        float f = this.size * (0.7F + this.world.random.nextFloat() * 0.6F);
+-                        double d4 = this.posX;
+-                        double d5 = this.posY;
+-                        double d6 = this.posZ;
+-
+-                        for (float f1 = 0.3F; f > 0.0F; f -= 0.22500001F) {
+-                            BlockPosition blockposition = new BlockPosition(d4, d5, d6);
+-                            IBlockData iblockdata = this.world.getType(blockposition);
+-
+-                            if (iblockdata.getBlock().getMaterial() != Material.AIR) {
+-                                float f2 = this.source != null ? this.source.a(this, this.world, blockposition, iblockdata) : iblockdata.getBlock().a((Entity) null);
+-
+-                                f -= (f2 + 0.3F) * 0.3F;
++        Block b = world.getChunkAt((int)posX >> 4, (int)posZ >> 4).getBlockData(new BlockPosition(posX, posY, posZ)).getBlock(); // TacoSpigot - get block of the explosion
++
++        if(!b.getMaterial().isLiquid()) { //TacoSpigot - skip calculating what blocks to blow up in water/lava
++            for (int k = 0; k < 16; ++k) {
++                for (i = 0; i < 16; ++i) {
++                    for (j = 0; j < 16; ++j) {
++                        if (k == 0 || k == 15 || i == 0 || i == 15 || j == 0 || j == 15) {
++                            double d0 = (double) ((float) k / 15.0F * 2.0F - 1.0F);
++                            double d1 = (double) ((float) i / 15.0F * 2.0F - 1.0F);
++                            double d2 = (double) ((float) j / 15.0F * 2.0F - 1.0F);
++                            double d3 = Math.sqrt(d0 * d0 + d1 * d1 + d2 * d2);
++
++                            d0 /= d3;
++                            d1 /= d3;
++                            d2 /= d3;
++                            float f = this.size * (0.7F + this.world.random.nextFloat() * 0.6F);
++                            double d4 = this.posX;
++                            double d5 = this.posY;
++                            double d6 = this.posZ;
++
++                            for (float f1 = 0.3F; f > 0.0F; f -= 0.22500001F) {
++                                BlockPosition blockposition = new BlockPosition(d4, d5, d6);
++                                IBlockData iblockdata = this.world.getType(blockposition);
++
++                                if (iblockdata.getBlock().getMaterial() != Material.AIR) {
++                                    float f2 = this.source != null ? this.source.a(this, this.world, blockposition, iblockdata) : iblockdata.getBlock().a((Entity) null);
++
++                                    f -= (f2 + 0.3F) * 0.3F;
++                                }
++
++                                if (f > 0.0F && (this.source == null || this.source.a(this, this.world, blockposition, iblockdata, f)) && blockposition.getY() < 256 && blockposition.getY() >= 0) { // CraftBukkit - don't wrap explosions
++                                    hashset.add(blockposition);
++                                }
++
++                                d4 += d0 * 0.30000001192092896D;
++                                d5 += d1 * 0.30000001192092896D;
++                                d6 += d2 * 0.30000001192092896D;
+                             }
+-
+-                            if (f > 0.0F && (this.source == null || this.source.a(this, this.world, blockposition, iblockdata, f)) && blockposition.getY() < 256 && blockposition.getY() >= 0) { // CraftBukkit - don't wrap explosions
+-                                hashset.add(blockposition);
+-                            }
+-
+-                            d4 += d0 * 0.30000001192092896D;
+-                            d5 += d1 * 0.30000001192092896D;
+-                            d6 += d2 * 0.30000001192092896D;
+                         }
+                     }
+                 }
+diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
+index 22e39bd..d4f337e 100644
+--- a/src/main/java/net/minecraft/server/World.java
++++ b/src/main/java/net/minecraft/server/World.java
+@@ -1233,6 +1233,8 @@ public abstract class World implements IBlockAccess {
+ 
+         if (entity instanceof EntityItem) return arraylist; // PaperSpigot - Optimize item movement
+         if (entity instanceof EntityArmorStand) return arraylist; // TacoSpigot - Optimize armor stand movement
++        if (entity instanceof EntityTNTPrimed) return arraylist; // TacoSpigot - Optimize tnt entity movement
++        if (entity instanceof EntityFallingBlock) return arraylist; // TacoSpigot - Optimize falling block movement
+ 
+         double d0 = 0.25D;
+         List list = this.getEntities(entity, axisalignedbb.grow(d0, d0, d0));
+-- 
+2.7.4
+

--- a/PaperSpigot-Server-Patches/0024-optimize-tnt-entity-and-falling-block-movement.patch
+++ b/PaperSpigot-Server-Patches/0024-optimize-tnt-entity-and-falling-block-movement.patch
@@ -1,36 +1,48 @@
-From b6b625a5bb4aeffd73c1559275af4695e711dc2b Mon Sep 17 00:00:00 2001
+From af5960c7f755434cd20925c847d208a39a9ed099 Mon Sep 17 00:00:00 2001
 From: nirmal <upwardshybriding@gmail.com>
 Date: Wed, 29 Nov 2017 22:14:32 -0500
 Subject: [PATCH] optimize tnt entity and falling block movement
 
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 2da303f..b32ffa9 100644
+index 2da303f..884eca8 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
-@@ -515,7 +515,7 @@ public abstract class Entity implements ICommandListener {
+@@ -515,7 +515,15 @@ public abstract class Entity implements ICommandListener {
                  }
              }
  
 -            List list = this.world.getCubes(this, this.getBoundingBox().a(d0, d1, d2));
-+            List list = this.world.getCubes(this, this.getBoundingBox().a(0, d1, 0)); // TacoSpigot - get y axis blocks
++            boolean axisScan = d0 * d1 * d2 > 25; // TacoSpigot - do axis by axis scan if the entity is travelling a large area
++
++            List list;
++            if(axisScan) {
++                list = this.world.getCubes(this, this.getBoundingBox().a(0, d1, 0)); // TacoSpigot - get y axis blocks
++            } else {
++                list = this.world.getCubes(this, this.getBoundingBox().a(d0, d1, d2));
++            }
++
              AxisAlignedBB axisalignedbb = this.getBoundingBox();
  
              AxisAlignedBB axisalignedbb1;
-@@ -527,6 +527,8 @@ public abstract class Entity implements ICommandListener {
+@@ -527,6 +535,10 @@ public abstract class Entity implements ICommandListener {
              this.a(this.getBoundingBox().c(0.0D, d1, 0.0D));
              boolean flag1 = this.onGround || d7 != d1 && d7 < 0.0D;
  
-+            list = this.world.getCubes(this, this.getBoundingBox().a(d0, 0, 0)); // TacoSpigot - get x axis blocks
++            if(axisScan) {
++                list = this.world.getCubes(this, this.getBoundingBox().a(d0, 0, 0)); // TacoSpigot - get x axis blocks
++            }
 +
              AxisAlignedBB axisalignedbb2;
              Iterator iterator1;
  
-@@ -536,6 +538,8 @@ public abstract class Entity implements ICommandListener {
+@@ -536,6 +548,10 @@ public abstract class Entity implements ICommandListener {
  
              this.a(this.getBoundingBox().c(d0, 0.0D, 0.0D));
  
-+            list = this.world.getCubes(this, this.getBoundingBox().a(0, 0, d2)); // TacoSpigot - get z axis blocks
++            if(axisScan) {
++                list = this.world.getCubes(this, this.getBoundingBox().a(0, 0, d2)); // TacoSpigot - get z axis blocks
++            }
 +
              for (iterator1 = list.iterator(); iterator1.hasNext(); d2 = axisalignedbb2.c(this.getBoundingBox(), d2)) {
                  axisalignedbb2 = (AxisAlignedBB) iterator1.next();


### PR DESCRIPTION
Calculates entity movement collision by getting the blocks it collides with axis by axis rather than getting the entire cube of its movement. This helps for entities with a high-velocity Ex: A piece of TNT going 100 blocks right, 100 blocks up, and 100 blocks forwards will currently scan and load all chunks within that 100x100x100 area. With this patch, it scans axis at a time so it gets all the blocks on its individual axis' and then checks for a collision as normal. (100+100+100 scan with the patch vs 100x100x100 without)

Optimized TNT and falling block entities within close ranges of each other (Like in a TNT cannon). The getCubes method in the world class doesn't need to check entity on entity collision for TNT and falling block entities.

Optimized TNT explosions by not calculating the blocks it has to break if it's in a liquid.

Example of a cannon that I was trying to optimize for: https://www.youtube.com/watch?v=ZCm_6_N6O_E&t=17s

It fires many TNT at high velocities causing the server to stutter for a while before returning to normal.

Comparison of tps using Massive Lag when firing the cannon linked above: 
Current TacoSpigot: http://i.prntscr.com/rT1UVxUSRuCZSUwfuMdVtw.png
Patched TacoSpigot: http://i.prntscr.com/WO0yXpXkRamn_3H-Q0xSQg.png