### PR TITLE
1.13.2 support

### DIFF
--- a/Paper-API-Patches/0001-POM-changes.patch
+++ b/Paper-API-Patches/0001-POM-changes.patch
@@ -8,7 +8,7 @@ diff --git a/pom.xml b/pom.xml
 index b83c6eb1..8fd5d4c0 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -4,18 +4,18 @@
+@@ -4,16 +4,16 @@
      <modelVersion>4.0.0</modelVersion>
  
      <parent>
@@ -18,12 +18,10 @@ index b83c6eb1..8fd5d4c0 100644
 +        <artifactId>parent</artifactId>
          <version>dev-SNAPSHOT</version>
      </parent>
- 
--    <groupId>com.destroystokyo.paper</groupId>
+
 -    <artifactId>paper-api</artifactId>
-+    <groupId>net.techcable.tacospigot</groupId>
 +    <artifactId>tacospigot-api</artifactId>
-     <version>1.12.2-R0.1-SNAPSHOT</version>
+     <version>1.13.2-R0.1-SNAPSHOT</version>
      <packaging>jar</packaging>
  
 -    <name>Paper-API</name>

--- a/Paper-API-Patches/0001-POM-changes.patch
+++ b/Paper-API-Patches/0001-POM-changes.patch
@@ -1,14 +1,14 @@
-From 5d4ffe43843d4614cceb32408d4db255335f53a5 Mon Sep 17 00:00:00 2001
+From 2533bb902881efd900da5a1f7194dc06e816814c Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@outlook.com>
 Date: Tue, 6 Jan 2015 22:12:31 -0600
 Subject: [PATCH] POM changes
 
 
 diff --git a/pom.xml b/pom.xml
-index b83c6eb1..8fd5d4c0 100644
+index 3e2c1cd5..d08646df 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -4,16 +4,16 @@
+@@ -4,17 +4,17 @@
      <modelVersion>4.0.0</modelVersion>
  
      <parent>
@@ -18,7 +18,7 @@ index b83c6eb1..8fd5d4c0 100644
 +        <artifactId>parent</artifactId>
          <version>dev-SNAPSHOT</version>
      </parent>
-
+ 
 -    <artifactId>paper-api</artifactId>
 +    <artifactId>tacospigot-api</artifactId>
      <version>1.13.2-R0.1-SNAPSHOT</version>
@@ -32,5 +32,5 @@ index b83c6eb1..8fd5d4c0 100644
  
      <properties>
 -- 
-2.14.2
+2.15.1.windows.2
 

--- a/Paper-API-Patches/0003-Better-version-checking.patch
+++ b/Paper-API-Patches/0003-Better-version-checking.patch
@@ -260,8 +260,8 @@ index c45faf4c..bfb4ef63 100644
 +import java.util.Objects;
  import java.util.Set;
  import java.util.concurrent.locks.ReentrantLock;
- import java.util.logging.Level;
-@@ -33,6 +34,12 @@ import java.io.InputStreamReader;
+ import org.json.simple.JSONObject;
+@@ -31,6 +32,12 @@ import java.io.InputStreamReader;
  import java.net.HttpURLConnection;
  import com.destroystokyo.paper.VersionHistoryManager;
  // Paper end
@@ -274,10 +274,10 @@ index c45faf4c..bfb4ef63 100644
  
  public class VersionCommand extends BukkitCommand {
      public VersionCommand(String name) {
-@@ -205,6 +212,24 @@ public class VersionCommand extends BukkitCommand {
+@@ -203,6 +210,24 @@ public class VersionCommand extends BukkitCommand {
          }
      }
- 
+
 +    // TacoSpigot start - Delegate to our version-checking logic
 +    private void obtainVersion() {
 +        try {
@@ -299,34 +299,34 @@ index c45faf4c..bfb4ef63 100644
      // Paper start
      private void obtainVersion() {
          String version = Bukkit.getVersion();
-@@ -242,6 +267,9 @@ public class VersionCommand extends BukkitCommand {
+@@ -240,6 +265,9 @@ public class VersionCommand extends BukkitCommand {
              setVersionMessage("Unknown version, custom build?");
          }
      }
 +    */
 +    // TacoSpigot end
 +
- 
+
      private void setVersionMessage(String msg) {
          lastCheck = System.currentTimeMillis();
-@@ -259,6 +287,8 @@ public class VersionCommand extends BukkitCommand {
+@@ -257,6 +285,8 @@ public class VersionCommand extends BukkitCommand {
          }
      }
- 
+
 +    // TacoSpigot start - remove Paper's check
 +    /*
      // Paper start
      private static int getDistance(String repo, String verInfo) {
          try {
-@@ -282,7 +312,6 @@ public class VersionCommand extends BukkitCommand {
+@@ -280,7 +310,6 @@ public class VersionCommand extends BukkitCommand {
              } finally {
                  reader.close();
              }
 -            */
      }
- 
+
      private static int getFromJenkins(int currentVer) {
-@@ -336,4 +365,6 @@ public class VersionCommand extends BukkitCommand {
+@@ -333,4 +362,6 @@ public class VersionCommand extends BukkitCommand {
          }
      }
      // Paper end

--- a/Paper-API-Patches/0003-Better-version-checking.patch
+++ b/Paper-API-Patches/0003-Better-version-checking.patch
@@ -1,4 +1,4 @@
-From a6e285cb74b857ff3824c0ca15c54395f9ff5755 Mon Sep 17 00:00:00 2001
+From 1b2f53cd31cd5e72beb7b379315c6863a3261403 Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@techcable.net>
 Date: Mon, 24 Apr 2017 11:07:19 -0700
 Subject: [PATCH] Better version checking
@@ -250,7 +250,7 @@ index 00000000..d68c6e0e
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/command/defaults/VersionCommand.java b/src/main/java/org/bukkit/command/defaults/VersionCommand.java
-index c45faf4c..bfb4ef63 100644
+index 5cebb245..7785ff8c 100644
 --- a/src/main/java/org/bukkit/command/defaults/VersionCommand.java
 +++ b/src/main/java/org/bukkit/command/defaults/VersionCommand.java
 @@ -20,6 +20,7 @@ import java.io.IOException;
@@ -277,7 +277,7 @@ index c45faf4c..bfb4ef63 100644
 @@ -203,6 +210,24 @@ public class VersionCommand extends BukkitCommand {
          }
      }
-
+ 
 +    // TacoSpigot start - Delegate to our version-checking logic
 +    private void obtainVersion() {
 +        try {
@@ -306,13 +306,13 @@ index c45faf4c..bfb4ef63 100644
 +    */
 +    // TacoSpigot end
 +
-
+ 
      private void setVersionMessage(String msg) {
          lastCheck = System.currentTimeMillis();
 @@ -257,6 +285,8 @@ public class VersionCommand extends BukkitCommand {
          }
      }
-
+ 
 +    // TacoSpigot start - remove Paper's check
 +    /*
      // Paper start
@@ -324,7 +324,7 @@ index c45faf4c..bfb4ef63 100644
              }
 -            */
      }
-
+ 
      private static int getFromJenkins(int currentVer) {
 @@ -333,4 +362,6 @@ public class VersionCommand extends BukkitCommand {
          }
@@ -334,5 +334,5 @@ index c45faf4c..bfb4ef63 100644
 +    // TacoSpigot end
  }
 -- 
-2.17.0
+2.15.1.windows.2
 

--- a/Paper-Server-Patches/0001-POM-Changes.patch
+++ b/Paper-Server-Patches/0001-POM-Changes.patch
@@ -1,11 +1,11 @@
-From ba635a4700cdda089bd0ddc3a9ed2f2fb3287059 Mon Sep 17 00:00:00 2001
+From c5cf88654ce2a47d434d6d58bcf66a3b38d3da56 Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@outlook.com>
 Date: Thu, 19 Mar 2015 19:41:15 -0500
 Subject: [PATCH] POM Changes
 
 
 diff --git a/pom.xml b/pom.xml
-index 07e780b6..d3ce5e5b 100644
+index 57042c171..75d6a6dc3 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -1,11 +1,11 @@
@@ -23,7 +23,7 @@ index 07e780b6..d3ce5e5b 100644
  
      <properties>
          <skipTests>true</skipTests>
-@@ -21,8 +21,8 @@
+@@ -21,16 +21,16 @@
      </properties>
  
      <parent>
@@ -34,8 +34,7 @@ index 07e780b6..d3ce5e5b 100644
          <version>dev-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
-@@ -29,8 +29,8 @@
-
+ 
      <dependencies>
          <dependency>
 -            <groupId>com.destroystokyo.paper</groupId>
@@ -55,7 +54,7 @@ index 07e780b6..d3ce5e5b 100644
                  </configuration>
                  <executions>
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Versioning.java b/src/main/java/org/bukkit/craftbukkit/util/Versioning.java
-index 674096ca..4135e72c 100644
+index 674096cab..4135e72c9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Versioning.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Versioning.java
 @@ -11,7 +11,7 @@ public final class Versioning {
@@ -68,5 +67,5 @@ index 674096ca..4135e72c 100644
  
          if (stream != null) {
 -- 
-2.14.2
+2.15.1.windows.2
 

--- a/Paper-Server-Patches/0001-POM-Changes.patch
+++ b/Paper-Server-Patches/0001-POM-Changes.patch
@@ -8,23 +8,21 @@ diff --git a/pom.xml b/pom.xml
 index 07e780b6..d3ce5e5b 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -1,12 +1,12 @@
+@@ -1,11 +1,11 @@
  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
      <modelVersion>4.0.0</modelVersion>
--    <groupId>com.destroystokyo.paper</groupId>
 -    <artifactId>paper</artifactId>
-+    <groupId>net.techcable.tacospigot</groupId>
 +    <artifactId>server</artifactId>
      <packaging>jar</packaging>
-     <version>1.12.2-R0.1-SNAPSHOT</version>
+     <version>1.13.2-R0.1-SNAPSHOT</version>
 -    <name>Paper</name>
--    <url>https://github.com/PaperMC/Paper</url>
+-    <url>https://papermc.io</url>
 +    <name>TacoSpigot</name>
 +    <url>https://github.com/TacoSpigot/TacoSpigot</url>
  
      <properties>
-         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+         <skipTests>true</skipTests>
 @@ -21,8 +21,8 @@
      </properties>
  
@@ -36,9 +34,9 @@ index 07e780b6..d3ce5e5b 100644
          <version>dev-SNAPSHOT</version>
          <relativePath>../pom.xml</relativePath>
      </parent>
-@@ -36,8 +36,8 @@
-             <scope>compile</scope>
-         </dependency>
+@@ -29,8 +29,8 @@
+
+     <dependencies>
          <dependency>
 -            <groupId>com.destroystokyo.paper</groupId>
 -            <artifactId>paper-api</artifactId>
@@ -47,7 +45,7 @@ index 07e780b6..d3ce5e5b 100644
              <version>${project.version}</version>
              <scope>compile</scope>
          </dependency>
-@@ -149,7 +149,7 @@
+@@ -138,7 +138,7 @@
                  <artifactId>gitdescribe-maven-plugin</artifactId>
                  <version>1.3</version>
                  <configuration>

--- a/Paper-Server-Patches/0002-MC-Dev-Fixes.patch
+++ b/Paper-Server-Patches/0002-MC-Dev-Fixes.patch
@@ -5,75 +5,77 @@ Subject: [PATCH] MC-Dev Fixes
 
 Sometimes fernflower makes mistakes too
 
-diff --git a/src/main/java/net/minecraft/server/BlockStateEnum.java b/src/main/java/net/minecraft/server/BlockStateEnum.java
-index 66c459d8..9f43b2bb 100644
---- a/src/main/java/net/minecraft/server/BlockStateEnum.java
-+++ b/src/main/java/net/minecraft/server/BlockStateEnum.java
-@@ -27,7 +27,7 @@ public class BlockStateEnum<T extends Enum<T> & INamable> extends BlockState<T>
-         Iterator iterator = collection.iterator();
- 
-         while (iterator.hasNext()) {
--            Enum oenum = (Enum) iterator.next();
-+            T oenum = (T) iterator.next(); // TacoSpigot - fix decompile error
-             String s1 = ((INamable) oenum).getName();
- 
-             if (this.b.containsKey(s1)) {
 diff --git a/src/main/java/net/minecraft/server/BlockStateList.java b/src/main/java/net/minecraft/server/BlockStateList.java
 index a7846b84..b666c099 100644
 --- a/src/main/java/net/minecraft/server/BlockStateList.java
 +++ b/src/main/java/net/minecraft/server/BlockStateList.java
-@@ -87,7 +87,7 @@ public class BlockStateList {
-         if (!BlockStateList.a.matcher(s).matches()) {
-             throw new IllegalArgumentException("Block: " + block.getClass() + " has invalidly named property: " + s);
-         } else {
--            Iterator iterator = iblockstate.c().iterator();
-+            Iterator<T> iterator = iblockstate.c().iterator(); // TacoSpigot - generic iterator
- 
-             String s1;
- 
-@@ -96,7 +96,7 @@ public class BlockStateList {
-                     return s;
-                 }
- 
--                Comparable comparable = (Comparable) iterator.next();
-+                T comparable = iterator.next(); // TacoSpigot - fix fernflower error
- 
-                 s1 = iblockstate.a(comparable);
-             } while (BlockStateList.a.matcher(s1).matches());
-@@ -165,7 +165,7 @@ public class BlockStateList {
-             if (comparable == null) {
-                 throw new IllegalArgumentException("Cannot get property " + iblockstate + " as it does not exist in " + this.a.s());
-             } else {
--                return (Comparable) iblockstate.b().cast(comparable);
-+                return iblockstate.b().cast(comparable); // TacoSpigot - fix fernflower error
-             }
+@@ -31,17 +31,13 @@
+         List<A> list = Lists.newArrayList();
+         Stream<List<Comparable<?>>> stream = Stream.of(Collections.emptyList());
+
+-        IBlockState iblockstate;
+-
+-        for (UnmodifiableIterator unmodifiableiterator = this.c.values().iterator(); unmodifiableiterator.hasNext();stream = stream.flatMap((list1) -> {
+-            return iblockstate.d().stream().map((comparable) -> {
++        for (IBlockState<?> iblockstate : this.c.values()) {
++            stream = stream.flatMap((list1) -> iblockstate.d().stream().map((comparable) -> {
+                 List<Comparable<?>> list2 = Lists.newArrayList(list1);
+
+                 list2.add(comparable);
+                 return list2;
+-            });
+-        })) {
+-            iblockstate = (IBlockState) unmodifiableiterator.next();
++            }));
          }
- 
-diff --git a/src/main/java/net/minecraft/server/PacketEncoder.java b/src/main/java/net/minecraft/server/PacketEncoder.java
-index a6da6f5c..843fb2e4 100644
---- a/src/main/java/net/minecraft/server/PacketEncoder.java
-+++ b/src/main/java/net/minecraft/server/PacketEncoder.java
-@@ -19,7 +19,7 @@ public class PacketEncoder extends MessageToByteEncoder<Packet<?>> {
-         this.c = enumprotocoldirection;
-     }
- 
--    protected void a(ChannelHandlerContext channelhandlercontext, Packet<?> packet, ByteBuf bytebuf) throws Exception {
-+    protected void encode(ChannelHandlerContext channelhandlercontext, Packet<?> packet, ByteBuf bytebuf) throws Exception { // TacoSpigot - fix decompiler issue
-         EnumProtocol enumprotocol = (EnumProtocol) channelhandlercontext.channel().attr(NetworkManager.c).get();
- 
-         if (enumprotocol == null) {
-@@ -48,7 +48,11 @@ public class PacketEncoder extends MessageToByteEncoder<Packet<?>> {
+
+         stream.forEach((list1) -> {
+@@ -51,15 +47,15 @@
+             map1.put(map2, a0);
+             list.add(a0);
+         });
+-        Iterator iterator = list.iterator();
++        Iterator<A> iterator = list.iterator();
+
+         while (iterator.hasNext()) {
+-            A a0 = (BlockDataAbstract) iterator.next();
++            A a0 = iterator.next();
+
+             a0.a((Map) map1);
          }
+
+-        this.d = ImmutableList.copyOf(list);
++        this.d = ImmutableList.copyOf((Iterable<S>)list);
      }
- 
-+    // TacoSpigot start - remove decompiler error
-+    /*
-     protected void encode(ChannelHandlerContext channelhandlercontext, Object object, ByteBuf bytebuf) throws Exception {
-         this.a(channelhandlercontext, (Packet) object, bytebuf);
+
+     public ImmutableList<S> a() {
+@@ -67,7 +63,7 @@
      }
-+    */
-+    // TacoSpigot end
- }
+
+     public S getBlockData() {
+-        return (IBlockDataHolder) this.d.get(0);
++        return this.d.get(0);
+     }
+
+     public O getBlock() {
+@@ -121,7 +117,7 @@
+                 if (collection.size() <= 1) {
+                     throw new IllegalArgumentException(this.a + " attempted use property " + s + " with <= 1 possible values");
+                 } else {
+-                    Iterator iterator = collection.iterator();
++                    Iterator<T> iterator = collection.iterator();
+
+                     String s1;
+
+@@ -134,7 +130,7 @@
+                             return;
+                         }
+
+-                        T t0 = (Comparable) iterator.next();
++                        T t0 = iterator.next();
+
+                         s1 = iblockstate.a(t0);
+                     } while (BlockStateList.a.matcher(s1).matches());
 -- 
 2.13.1
 

--- a/Paper-Server-Patches/0002-MC-Dev-Fixes.patch
+++ b/Paper-Server-Patches/0002-MC-Dev-Fixes.patch
@@ -1,4 +1,4 @@
-From eccb425149abe6997262ff353c20126d2ebaa6c8 Mon Sep 17 00:00:00 2001
+From e1112a0a7fa710e5689a7cd489ee6c01297a98fe Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@techcable.net>
 Date: Sun, 3 Apr 2016 14:05:27 -0700
 Subject: [PATCH] MC-Dev Fixes
@@ -6,13 +6,13 @@ Subject: [PATCH] MC-Dev Fixes
 Sometimes fernflower makes mistakes too
 
 diff --git a/src/main/java/net/minecraft/server/BlockStateList.java b/src/main/java/net/minecraft/server/BlockStateList.java
-index a7846b84..b666c099 100644
+index 47b528b0a..9e2c21627 100644
 --- a/src/main/java/net/minecraft/server/BlockStateList.java
 +++ b/src/main/java/net/minecraft/server/BlockStateList.java
-@@ -31,17 +31,13 @@
+@@ -31,17 +31,13 @@ public class BlockStateList<O, S extends IBlockDataHolder<S>> {
          List<A> list = Lists.newArrayList();
          Stream<List<Comparable<?>>> stream = Stream.of(Collections.emptyList());
-
+ 
 -        IBlockState iblockstate;
 -
 -        for (UnmodifiableIterator unmodifiableiterator = this.c.values().iterator(); unmodifiableiterator.hasNext();stream = stream.flatMap((list1) -> {
@@ -20,7 +20,7 @@ index a7846b84..b666c099 100644
 +        for (IBlockState<?> iblockstate : this.c.values()) {
 +            stream = stream.flatMap((list1) -> iblockstate.d().stream().map((comparable) -> {
                  List<Comparable<?>> list2 = Lists.newArrayList(list1);
-
+ 
                  list2.add(comparable);
                  return list2;
 -            });
@@ -28,54 +28,54 @@ index a7846b84..b666c099 100644
 -            iblockstate = (IBlockState) unmodifiableiterator.next();
 +            }));
          }
-
+ 
          stream.forEach((list1) -> {
-@@ -51,15 +47,15 @@
+@@ -51,15 +47,15 @@ public class BlockStateList<O, S extends IBlockDataHolder<S>> {
              map1.put(map2, a0);
              list.add(a0);
          });
 -        Iterator iterator = list.iterator();
 +        Iterator<A> iterator = list.iterator();
-
+ 
          while (iterator.hasNext()) {
 -            A a0 = (BlockDataAbstract) iterator.next();
 +            A a0 = iterator.next();
-
+ 
              a0.a((Map) map1);
          }
-
+ 
 -        this.d = ImmutableList.copyOf(list);
 +        this.d = ImmutableList.copyOf((Iterable<S>)list);
      }
-
+ 
      public ImmutableList<S> a() {
-@@ -67,7 +63,7 @@
+@@ -67,7 +63,7 @@ public class BlockStateList<O, S extends IBlockDataHolder<S>> {
      }
-
+ 
      public S getBlockData() {
 -        return (IBlockDataHolder) this.d.get(0);
 +        return this.d.get(0);
      }
-
+ 
      public O getBlock() {
-@@ -121,7 +117,7 @@
+@@ -121,7 +117,7 @@ public class BlockStateList<O, S extends IBlockDataHolder<S>> {
                  if (collection.size() <= 1) {
                      throw new IllegalArgumentException(this.a + " attempted use property " + s + " with <= 1 possible values");
                  } else {
 -                    Iterator iterator = collection.iterator();
 +                    Iterator<T> iterator = collection.iterator();
-
+ 
                      String s1;
-
-@@ -134,7 +130,7 @@
+ 
+@@ -134,7 +130,7 @@ public class BlockStateList<O, S extends IBlockDataHolder<S>> {
                              return;
                          }
-
+ 
 -                        T t0 = (Comparable) iterator.next();
 +                        T t0 = iterator.next();
-
+ 
                          s1 = iblockstate.a(t0);
                      } while (BlockStateList.a.matcher(s1).matches());
 -- 
-2.13.1
+2.15.1.windows.2
 

--- a/Paper-Server-Patches/0003-Show-TacoSpigot-in-client-crashes-server-lists-and-M.patch
+++ b/Paper-Server-Patches/0003-Show-TacoSpigot-in-client-crashes-server-lists-and-M.patch
@@ -1,4 +1,4 @@
-From 0b230c5a588e9eacd80009cd8ff7c3b01bffc54a Mon Sep 17 00:00:00 2001
+From cea9b867af4f4849400f9b2910c586634756c3fb Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@outlook.com>
 Date: Sat, 7 Mar 2015 22:55:25 -0600
 Subject: [PATCH] Show 'TacoSpigot' in client crashes, server lists, and Mojang
@@ -6,10 +6,10 @@ Subject: [PATCH] Show 'TacoSpigot' in client crashes, server lists, and Mojang
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index f82e22b2..9bfb4d7d 100644
+index 4e648ee73..f4d654890 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1149,7 +1149,7 @@ public abstract class MinecraftServer implements ICommandListener, Runnable, IAs
+@@ -1340,7 +1340,7 @@ public abstract class MinecraftServer implements IAsyncTaskHandler, IMojangStati
      }
  
      public String getServerModName() {
@@ -19,5 +19,5 @@ index f82e22b2..9bfb4d7d 100644
  
      public CrashReport b(CrashReport crashreport) {
 -- 
-2.17.0
+2.15.1.windows.2
 

--- a/Paper-Server-Patches/0004-TacoSpigot-configuration-files.patch
+++ b/Paper-Server-Patches/0004-TacoSpigot-configuration-files.patch
@@ -1,14 +1,14 @@
-From 272f3ba5e22196674af2c47f63f931de44d73d48 Mon Sep 17 00:00:00 2001
+From e85f39c8d6024e07704d6df2e540f2d400e9ec79 Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@outlook.com>
 Date: Sun, 26 Jul 2015 16:50:26 -0700
 Subject: [PATCH] TacoSpigot configuration files
 
 
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 9f5388ed..5c52633f 100644
+index e11e22836..8b013dadb 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -160,6 +160,7 @@ public abstract class World implements IBlockAccess {
+@@ -160,6 +160,7 @@ public abstract class World implements IEntityAccess, GeneratorAccess, IIBlockAc
  
      public final com.destroystokyo.paper.PaperWorldConfig paperConfig; // Paper
      public final ChunkPacketBlockController chunkPacketBlockController; // Paper - Anti-Xray
@@ -16,7 +16,7 @@ index 9f5388ed..5c52633f 100644
  
      public final co.aikar.timings.WorldTimingsHandler timings; // Paper
      public boolean guardEntityList; // Spigot // Paper - public
-@@ -186,6 +187,7 @@ public abstract class World implements IBlockAccess {
+@@ -186,6 +187,7 @@ public abstract class World implements IEntityAccess, GeneratorAccess, IIBlockAc
          this.spigotConfig = new org.spigotmc.SpigotWorldConfig( worlddata.getName() ); // Spigot
          this.paperConfig = new com.destroystokyo.paper.PaperWorldConfig(worlddata.getName(), this.spigotConfig); // Paper
          this.chunkPacketBlockController = this.paperConfig.antiXray ? new ChunkPacketBlockControllerAntiXray(this.paperConfig) : ChunkPacketBlockController.NO_OPERATION_INSTANCE; // Paper - Anti-Xray
@@ -26,7 +26,7 @@ index 9f5388ed..5c52633f 100644
          this.ticksPerAnimalSpawns = this.getServer().getTicksPerAnimalSpawns(); // CraftBukkit
 diff --git a/src/main/java/net/techcable/tacospigot/TacoSpigotConfig.java b/src/main/java/net/techcable/tacospigot/TacoSpigotConfig.java
 new file mode 100644
-index 00000000..ce66b1c3
+index 000000000..ce66b1c35
 --- /dev/null
 +++ b/src/main/java/net/techcable/tacospigot/TacoSpigotConfig.java
 @@ -0,0 +1,105 @@
@@ -137,7 +137,7 @@ index 00000000..ce66b1c3
 +}
 diff --git a/src/main/java/net/techcable/tacospigot/TacoSpigotWorldConfig.java b/src/main/java/net/techcable/tacospigot/TacoSpigotWorldConfig.java
 new file mode 100644
-index 00000000..2bc58772
+index 000000000..2bc587722
 --- /dev/null
 +++ b/src/main/java/net/techcable/tacospigot/TacoSpigotWorldConfig.java
 @@ -0,0 +1,65 @@
@@ -207,7 +207,7 @@ index 00000000..2bc58772
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 80702f6f..434dfff8 100644
+index 92c429dde..7727e0952 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -791,6 +791,7 @@ public final class CraftServer implements Server {
@@ -236,7 +236,7 @@ index 80702f6f..434dfff8 100644
          return result;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 21628e19..9f27e129 100644
+index c9a6b5afb..3252dda0a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -144,6 +144,14 @@ public class Main {
@@ -263,5 +263,5 @@ index 21628e19..9f27e129 100644
                  MinecraftServer.main(options);
              } catch (Throwable t) {
 -- 
-2.17.0
+2.15.1.windows.2
 

--- a/Paper-Server-Patches/0004-TacoSpigot-configuration-files.patch
+++ b/Paper-Server-Patches/0004-TacoSpigot-configuration-files.patch
@@ -8,15 +8,15 @@ diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/m
 index 9f5388ed..5c52633f 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -141,6 +141,7 @@ public abstract class World implements IBlockAccess {
+@@ -160,6 +160,7 @@ public abstract class World implements IBlockAccess {
  
      public final com.destroystokyo.paper.PaperWorldConfig paperConfig; // Paper
      public final ChunkPacketBlockController chunkPacketBlockController; // Paper - Anti-Xray
 +    public final net.techcable.tacospigot.TacoSpigotWorldConfig tacoSpigotConfig; // TacoSpigot
  
      public final co.aikar.timings.WorldTimingsHandler timings; // Paper
-     private boolean guardEntityList; // Spigot
-@@ -173,6 +174,7 @@ public abstract class World implements IBlockAccess {
+     public boolean guardEntityList; // Spigot // Paper - public
+@@ -186,6 +187,7 @@ public abstract class World implements IBlockAccess {
          this.spigotConfig = new org.spigotmc.SpigotWorldConfig( worlddata.getName() ); // Spigot
          this.paperConfig = new com.destroystokyo.paper.PaperWorldConfig(worlddata.getName(), this.spigotConfig); // Paper
          this.chunkPacketBlockController = this.paperConfig.antiXray ? new ChunkPacketBlockControllerAntiXray(this.paperConfig) : ChunkPacketBlockController.NO_OPERATION_INSTANCE; // Paper - Anti-Xray
@@ -210,15 +210,15 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/ja
 index 80702f6f..434dfff8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -743,6 +743,7 @@ public final class CraftServer implements Server {
+@@ -791,6 +791,7 @@ public final class CraftServer implements Server {
  
          org.spigotmc.SpigotConfig.init((File) console.options.valueOf("spigot-settings")); // Spigot
          com.destroystokyo.paper.PaperConfig.init((File) console.options.valueOf("paper-settings")); // Paper
 +        net.techcable.tacospigot.TacoSpigotConfig.init((File) console.options.valueOf("taco-settings")); // TacoSpigot
-         for (WorldServer world : console.worlds) {
+         for (WorldServer world : console.getWorlds()) {
              world.worldData.setDifficulty(difficulty);
              world.setSpawnFlags(monsters, animals);
-@@ -759,6 +760,7 @@ public final class CraftServer implements Server {
+@@ -807,6 +808,7 @@ public final class CraftServer implements Server {
              }
              world.spigotConfig.init(); // Spigot
              world.paperConfig.init(); // Paper
@@ -226,7 +226,7 @@ index 80702f6f..434dfff8 100644
          }
  
          Plugin[] pluginClone = pluginManager.getPlugins().clone(); // Paper
-@@ -1447,7 +1449,7 @@ public final class CraftServer implements Server {
+@@ -1521,7 +1523,7 @@ public final class CraftServer implements Server {
  
          for (JsonListEntry entry : playerList.getProfileBans().getValues()) {
              result.add(getOfflinePlayer((GameProfile) entry.getKey()));
@@ -239,7 +239,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/
 index 21628e19..9f27e129 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
-@@ -142,6 +142,14 @@ public class Main {
+@@ -144,6 +144,14 @@ public class Main {
                          .defaultsTo("Unknown Server")
                          .describedAs("Name");
                  // Paper end
@@ -254,9 +254,9 @@ index 21628e19..9f27e129 100644
              }
          };
  
-@@ -218,6 +226,7 @@ public class Main {
-                     }
+@@ -239,6 +247,7 @@ public class Main {
                  }
+                 // Paper end
  
 +                net.techcable.tacospigot.TacoSpigotConfig.init((File) options.valueOf("taco-settings")); // TacoSpigot - initalize before library loading so we can access while loading
                  System.out.println("Loading libraries, please wait...");

--- a/Paper-Server-Patches/0006-Add-ArrowCollideEvent.patch
+++ b/Paper-Server-Patches/0006-Add-ArrowCollideEvent.patch
@@ -8,7 +8,7 @@ diff --git a/src/main/java/net/minecraft/server/EntityArrow.java b/src/main/java
 index 79ca071bc..38461bb81 100644
 --- a/src/main/java/net/minecraft/server/EntityArrow.java
 +++ b/src/main/java/net/minecraft/server/EntityArrow.java
-@@ -11,6 +11,11 @@ import org.bukkit.event.entity.EntityCombustByEntityEvent;
+@@ -13,6 +13,11 @@ import org.bukkit.event.entity.EntityCombustByEntityEvent;
  import org.bukkit.event.entity.EntityCombustEvent;
  import org.bukkit.event.player.PlayerPickupArrowEvent;
  // CraftBukkit end
@@ -20,7 +20,7 @@ index 79ca071bc..38461bb81 100644
  
  public abstract class EntityArrow extends Entity implements IProjectile {
  
-@@ -199,6 +204,16 @@ public abstract class EntityArrow extends Entity implements IProjectile {
+@@ -205,6 +210,16 @@ public abstract class EntityArrow extends Entity implements IProjectile {
              }
              // Paper end
  
@@ -34,9 +34,9 @@ index 79ca071bc..38461bb81 100644
 +            }
 +            // TacoSpigot end
 +
-             if (movingobjectposition != null) {
+             if (movingobjectposition != null && !flag) {
                  this.a(movingobjectposition);
-             }
+                 this.impulse = true;
 -- 
 2.11.0
 

--- a/Paper-Server-Patches/0007-Better-AsyncCatcher.patch
+++ b/Paper-Server-Patches/0007-Better-AsyncCatcher.patch
@@ -1,4 +1,4 @@
-From 973ab605e764629288e49712172be0a4130aff01 Mon Sep 17 00:00:00 2001
+From 176ca1cac7281dc65c0893ca58b43b87978f36b2 Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@techcable.net>
 Date: Fri, 18 Mar 2016 13:56:01 -0700
 Subject: [PATCH] Better AsyncCatcher
@@ -6,10 +6,10 @@ Subject: [PATCH] Better AsyncCatcher
 Async catching for PlayerChunkMap
 
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 99652ae3..727cf319 100644
+index b7dda8e28..c6f882dca 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -19,6 +19,9 @@ import javax.annotation.Nullable;
+@@ -17,6 +17,9 @@ import javax.annotation.Nullable;
  // CraftBukkit start
  import java.util.LinkedList;
  // CraftBukkit end
@@ -40,7 +40,7 @@ index 99652ae3..727cf319 100644
      private long k;
      private boolean l = true;
 diff --git a/src/main/java/org/spigotmc/AsyncCatcher.java b/src/main/java/org/spigotmc/AsyncCatcher.java
-index e44c2301..26a72ada 100644
+index e44c23016..26a72ada6 100644
 --- a/src/main/java/org/spigotmc/AsyncCatcher.java
 +++ b/src/main/java/org/spigotmc/AsyncCatcher.java
 @@ -1,6 +1,13 @@
@@ -90,5 +90,5 @@ index e44c2301..26a72ada 100644
 +    // TacoSpigot end
  }
 -- 
-2.16.2
+2.15.1.windows.2
 

--- a/Paper-Server-Patches/0007-Better-AsyncCatcher.patch
+++ b/Paper-Server-Patches/0007-Better-AsyncCatcher.patch
@@ -19,14 +19,14 @@ index 99652ae3..727cf319 100644
  
  public class PlayerChunkMap {
  
-@@ -41,12 +44,14 @@ public class PlayerChunkMap {
-         }
-     };
+@@ -27,12 +30,14 @@ public class PlayerChunkMap {
+         return entityplayer != null && (!entityplayer.isSpectator() || entityplayer.getWorldServer().getGameRules().getBoolean("spectatorsGenerateChunks"));
+     }; static final Predicate<EntityPlayer> CAN_GEN_CHUNKS = b; // Paper - OBFHELPER
      private final WorldServer world;
 -    private final List<EntityPlayer> managedPlayers = Lists.newArrayList();
 +    // TacoSpigot start - catch async access
 +    private final List<EntityPlayer> managedPlayers = AsyncCatcher.catchAsyncUsage(Lists.newArrayList(), "list access PlayerChunkMap.managedPlayers");
-     private final Long2ObjectMap<PlayerChunk> e = new Long2ObjectOpenHashMap(4096);
+     private final Long2ObjectMap<PlayerChunk> e = new Long2ObjectOpenHashMap(4096); Long2ObjectMap<PlayerChunk> getChunks() { return e; } // Paper - OBFHELPER
 -    private final Set<PlayerChunk> f = Sets.newHashSet();
 -    private final List<PlayerChunk> g = Lists.newLinkedList();
 -    private final List<PlayerChunk> h = Lists.newLinkedList();

--- a/Paper-Server-Patches/0008-Use-arrays-for-blockstates.patch
+++ b/Paper-Server-Patches/0008-Use-arrays-for-blockstates.patch
@@ -12,7 +12,7 @@ diff --git a/src/main/java/net/minecraft/server/BlockState.java b/src/main/java/
 index 1d626ce2..02c5339f 100644
 --- a/src/main/java/net/minecraft/server/BlockState.java
 +++ b/src/main/java/net/minecraft/server/BlockState.java
-@@ -2,14 +2,60 @@ package net.minecraft.server;
+@@ -2,15 +2,61 @@ package net.minecraft.server;
  
  import com.google.common.base.MoreObjects;
  
@@ -26,6 +26,7 @@ index 1d626ce2..02c5339f 100644
  
      private final Class<T> a;
      private final String b;
+     private Integer c;
 +    // TacoSpigot start
 +    private final int id;
 +
@@ -77,18 +78,10 @@ diff --git a/src/main/java/net/minecraft/server/BlockStateBoolean.java b/src/mai
 index 02b4956e..63e592ac 100644
 --- a/src/main/java/net/minecraft/server/BlockStateBoolean.java
 +++ b/src/main/java/net/minecraft/server/BlockStateBoolean.java
-@@ -42,6 +42,7 @@ public class BlockStateBoolean extends BlockState<Boolean> {
- 
-     // Spigot start
-     private int hashCode;
-+
-     public int hashCode() {
-         int hash = hashCode;
-         if (hash == 0) {
-@@ -51,4 +52,22 @@ public class BlockStateBoolean extends BlockState<Boolean> {
-         return hash;
+@@ -43,4 +43,22 @@ public class BlockStateBoolean extends BlockState<Boolean> {
+     public int c() {
+         return 31 * super.c() + this.a.hashCode();
      }
-     // Spigot end
 +    // TacoSpigot start
 +    @Override
 +    public int getValueId(Boolean value) {
@@ -112,15 +105,15 @@ diff --git a/src/main/java/net/minecraft/server/BlockStateEnum.java b/src/main/j
 index 2118587e..d12c5456 100644
 --- a/src/main/java/net/minecraft/server/BlockStateEnum.java
 +++ b/src/main/java/net/minecraft/server/BlockStateEnum.java
-@@ -43,7 +43,6 @@ public class BlockStateEnum<T extends Enum<T> & INamable> extends BlockState<T>
-     public Collection<T> c() {
+@@ -44,7 +44,6 @@ public class BlockStateEnum<T extends Enum<T> & INamable> extends BlockState<T>
+     public Collection<T> d() {
          return this.a;
      }
 -
      public Optional<T> b(String s) {
-         return Optional.fromNullable(this.b.get(s));
+         return Optional.ofNullable(this.b.get(s));
      }
-@@ -52,6 +51,23 @@ public class BlockStateEnum<T extends Enum<T> & INamable> extends BlockState<T>
+@@ -53,6 +52,23 @@ public class BlockStateEnum<T extends Enum<T> & INamable> extends BlockState<T>
          return ((INamable) t0).getName();
      }
  
@@ -141,19 +134,21 @@ index 2118587e..d12c5456 100644
 +    }
 +    // TacoSpigot end
 +
-     @Override // Paper - override equals as BlockStateEnum is a singleton
+     @Override // Paper start - override equals as BlockStateEnum is a singleton
      public boolean equals(Object object) {
         return this == object;
 diff --git a/src/main/java/net/minecraft/server/BlockStateInteger.java b/src/main/java/net/minecraft/server/BlockStateInteger.java
 index 403fa144..b6e144e8 100644
 --- a/src/main/java/net/minecraft/server/BlockStateInteger.java
 +++ b/src/main/java/net/minecraft/server/BlockStateInteger.java
-@@ -9,9 +9,40 @@ import java.util.HashSet;
+@@ -9,15 +9,43 @@ import java.util.HashSet;
  public class BlockStateInteger extends BlockState<Integer> {
  
      private final ImmutableSet<Integer> a;
+     // CraftBukkit start
+     public final int min;
+     public final int max;
 +    // TacoSpigot start
-+    private final int min, max;
 +    private final int range;
 +
 +    @Override
@@ -181,9 +176,10 @@ index 403fa144..b6e144e8 100644
  
      protected BlockStateInteger(String s, int i, int j) {
          super(s, Integer.class);
+         this.min = i;
+         this.max = j;
+         // CraftBukkit end
 +        // TacoSpigot start
-+        this.min = i;
-+        this.max = j;
 +        this.range = (max - min); // min and max are _both_ inclusive (there's a reason you're not supposed to do this :p)
 +        // TacoSpigot end
          if (i < 0) {
@@ -193,8 +189,8 @@ diff --git a/src/main/java/net/minecraft/server/BlockStateList.java b/src/main/j
 index b666c099..15b8c398 100644
 --- a/src/main/java/net/minecraft/server/BlockStateList.java
 +++ b/src/main/java/net/minecraft/server/BlockStateList.java
-@@ -24,6 +24,14 @@ import java.util.Map.Entry;
- import java.util.regex.Pattern;
+@@ -17,6 +17,14 @@ import java.util.Map.Entry;
+ import java.util.stream.Stream;
  import javax.annotation.Nullable;
  
 +// TacoSpigot start
@@ -205,97 +201,9 @@ index b666c099..15b8c398 100644
 +import net.techcable.tacospigot.TacoSpigotConfig;
 +// TacoSpigot end
 +
- public class BlockStateList {
+ public class BlockStateList<O, S extends IBlockDataHolder<S>> {
  
      private static final Pattern a = Pattern.compile("^[a-z0-9_]+$");
-@@ -147,16 +155,27 @@ public class BlockStateList {
-     static class BlockData extends BlockDataAbstract {
- 
-         private final Block a;
--        private final ImmutableMap<IBlockState<?>, Comparable<?>> b;
--        private ImmutableTable<IBlockState<?>, Comparable<?>, IBlockData> c;
-+        // TacoSpigot start
-+        private final ImmutableMap<IBlockState<?>, Comparable<?>> bAsImmutableMap;
-+        private final SimpleMap<IBlockState<?>, Comparable<?>> b;
-+        private SimpleTable<IBlockState, Comparable, IBlockData> c;
-+        // TacoSpigot end
- 
-         private BlockData(Block block, ImmutableMap<IBlockState<?>, Comparable<?>> immutablemap) {
-             this.a = block;
--            this.b = immutablemap;
-+            // TacoSpigot start
-+            this.bAsImmutableMap = immutablemap;
-+            if (TacoSpigotConfig.useArraysForBlockStates) {
-+                ImmutableArrayMap<IBlockState, Comparable> arrayMap = new ImmutableArrayMap<IBlockState, Comparable>(IBlockState::getId, BlockState::getById, (ImmutableMap) immutablemap);
-+                b = (key) -> arrayMap.get(key.getId());
-+            } else {
-+                b = immutablemap::get;
-+            }
-+            // TacoSpigot end
-         }
- 
-         public Collection<IBlockState<?>> s() {
--            return Collections.unmodifiableCollection(this.b.keySet());
-+            return Collections.unmodifiableCollection(this.bAsImmutableMap.keySet()); // TacoSpigot - use bAsImmutableMap
-         }
- 
-         public <T extends Comparable<T>> T get(IBlockState<T> iblockstate) {
-@@ -188,7 +207,7 @@ public class BlockStateList {
-         }
- 
-         public ImmutableMap<IBlockState<?>, Comparable<?>> t() {
--            return this.b;
-+            return this.bAsImmutableMap; // TacoSpigot
-         }
- 
-         public Block getBlock() {
-@@ -208,7 +227,7 @@ public class BlockStateList {
-                 throw new IllegalStateException();
-             } else {
-                 HashBasedTable hashbasedtable = HashBasedTable.create();
--                UnmodifiableIterator unmodifiableiterator = this.b.entrySet().iterator();
-+                UnmodifiableIterator unmodifiableiterator = this.bAsImmutableMap.entrySet().iterator(); // TacoSpigot - use bAsImmutableMap
- 
-                 while (unmodifiableiterator.hasNext()) {
-                     Entry entry = (Entry) unmodifiableiterator.next();
-@@ -218,18 +237,34 @@ public class BlockStateList {
-                     while (iterator.hasNext()) {
-                         Comparable comparable = (Comparable) iterator.next();
- 
--                        if (comparable != entry.getValue()) {
-+                        if (true) { // TacoSpigot - include everything in the table
-                             hashbasedtable.put(iblockstate, comparable, map.get(this.b(iblockstate, comparable)));
-                         }
-                     }
-                 }
- 
--                this.c = ImmutableTable.copyOf(hashbasedtable);
-+                // TacoSpigot start
-+                if (TacoSpigotConfig.useArraysForBlockStates) {
-+                    // I had some 'fun' getting this to work >:(
-+                    ImmutableArrayTable<IBlockState, Comparable, IBlockData> arrayTable = new ImmutableArrayTable<IBlockState, Comparable, IBlockData> (
-+                            IBlockState::getId,
-+                            BlockState::getById,
-+                            IBlockState::getValueId,
-+                            IBlockState::getByValueId,
-+                            hashbasedtable
-+                    );
-+                    this.c = (row, column) -> arrayTable.get(row.getId(), row.getValueId(column));
-+                } else {
-+                    ImmutableTable<IBlockState, Comparable, IBlockData> immutableTable = ImmutableTable.copyOf(hashbasedtable);
-+                    this.c = immutableTable::get;
-+                }
-+                // TacoSpigot end
-             }
-         }
- 
-         private Map<IBlockState<?>, Comparable<?>> b(IBlockState<?> iblockstate, Comparable<?> comparable) {
--            HashMap hashmap = Maps.newHashMap(this.b);
-+            HashMap hashmap = Maps.newHashMap(this.bAsImmutableMap); // TacoSpigot - use 'bAsImmutableMap'
-+
- 
-             hashmap.put(iblockstate, comparable);
-             return hashmap;
 diff --git a/src/main/java/net/minecraft/server/IBlockState.java b/src/main/java/net/minecraft/server/IBlockState.java
 index de548018..51143a6a 100644
 --- a/src/main/java/net/minecraft/server/IBlockState.java

--- a/Paper-Server-Patches/0008-Use-arrays-for-blockstates.patch
+++ b/Paper-Server-Patches/0008-Use-arrays-for-blockstates.patch
@@ -1,4 +1,4 @@
-From 15faec3adce1e9a2a205a94387b68d9d63fd286b Mon Sep 17 00:00:00 2001
+From 16920e397ef785fb38a3544d5fa54ffd8a5423f4 Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@techcable.net>
 Date: Thu, 31 Mar 2016 14:13:07 -0700
 Subject: [PATCH] Use arrays for blockstates
@@ -9,7 +9,7 @@ This data structure is usualy faster than a hashmap (especially when using the l
 Should help with redstone.
 
 diff --git a/src/main/java/net/minecraft/server/BlockState.java b/src/main/java/net/minecraft/server/BlockState.java
-index 1d626ce2..02c5339f 100644
+index d95c0955a..7f18997db 100644
 --- a/src/main/java/net/minecraft/server/BlockState.java
 +++ b/src/main/java/net/minecraft/server/BlockState.java
 @@ -2,15 +2,61 @@ package net.minecraft.server;
@@ -75,7 +75,7 @@ index 1d626ce2..02c5339f 100644
  
      public String a() {
 diff --git a/src/main/java/net/minecraft/server/BlockStateBoolean.java b/src/main/java/net/minecraft/server/BlockStateBoolean.java
-index 02b4956e..63e592ac 100644
+index 4c1d39d67..9c2dc5893 100644
 --- a/src/main/java/net/minecraft/server/BlockStateBoolean.java
 +++ b/src/main/java/net/minecraft/server/BlockStateBoolean.java
 @@ -43,4 +43,22 @@ public class BlockStateBoolean extends BlockState<Boolean> {
@@ -102,7 +102,7 @@ index 02b4956e..63e592ac 100644
 +    // TacoSpigot end
  }
 diff --git a/src/main/java/net/minecraft/server/BlockStateEnum.java b/src/main/java/net/minecraft/server/BlockStateEnum.java
-index 2118587e..d12c5456 100644
+index 259da0aa0..cbe36b8d7 100644
 --- a/src/main/java/net/minecraft/server/BlockStateEnum.java
 +++ b/src/main/java/net/minecraft/server/BlockStateEnum.java
 @@ -44,7 +44,6 @@ public class BlockStateEnum<T extends Enum<T> & INamable> extends BlockState<T>
@@ -136,15 +136,12 @@ index 2118587e..d12c5456 100644
 +
      @Override // Paper start - override equals as BlockStateEnum is a singleton
      public boolean equals(Object object) {
-        return this == object;
+         return this == object;
 diff --git a/src/main/java/net/minecraft/server/BlockStateInteger.java b/src/main/java/net/minecraft/server/BlockStateInteger.java
-index 403fa144..b6e144e8 100644
+index 2f12e15e0..9fd2fe451 100644
 --- a/src/main/java/net/minecraft/server/BlockStateInteger.java
 +++ b/src/main/java/net/minecraft/server/BlockStateInteger.java
-@@ -9,15 +9,43 @@ import java.util.HashSet;
- public class BlockStateInteger extends BlockState<Integer> {
- 
-     private final ImmutableSet<Integer> a;
+@@ -12,12 +12,40 @@ public class BlockStateInteger extends BlockState<Integer> {
      // CraftBukkit start
      public final int min;
      public final int max;
@@ -186,10 +183,10 @@ index 403fa144..b6e144e8 100644
              throw new IllegalArgumentException("Min value of " + s + " must be 0 or greater");
          } else if (j <= i) {
 diff --git a/src/main/java/net/minecraft/server/BlockStateList.java b/src/main/java/net/minecraft/server/BlockStateList.java
-index b666c099..15b8c398 100644
+index 9e2c21627..be1b1065c 100644
 --- a/src/main/java/net/minecraft/server/BlockStateList.java
 +++ b/src/main/java/net/minecraft/server/BlockStateList.java
-@@ -17,6 +17,14 @@ import java.util.Map.Entry;
+@@ -17,6 +17,14 @@ import java.util.stream.Collectors;
  import java.util.stream.Stream;
  import javax.annotation.Nullable;
  
@@ -205,7 +202,7 @@ index b666c099..15b8c398 100644
  
      private static final Pattern a = Pattern.compile("^[a-z0-9_]+$");
 diff --git a/src/main/java/net/minecraft/server/IBlockState.java b/src/main/java/net/minecraft/server/IBlockState.java
-index de548018..51143a6a 100644
+index 5afc16e33..a33a51339 100644
 --- a/src/main/java/net/minecraft/server/IBlockState.java
 +++ b/src/main/java/net/minecraft/server/IBlockState.java
 @@ -14,4 +14,12 @@ public interface IBlockState<T extends Comparable<T>> {
@@ -223,7 +220,7 @@ index de548018..51143a6a 100644
  }
 diff --git a/src/main/java/net/techcable/tacospigot/ImmutableArrayMap.java b/src/main/java/net/techcable/tacospigot/ImmutableArrayMap.java
 new file mode 100644
-index 00000000..6fc4c57a
+index 000000000..6fc4c57a6
 --- /dev/null
 +++ b/src/main/java/net/techcable/tacospigot/ImmutableArrayMap.java
 @@ -0,0 +1,143 @@
@@ -372,7 +369,7 @@ index 00000000..6fc4c57a
 +}
 diff --git a/src/main/java/net/techcable/tacospigot/ImmutableArrayTable.java b/src/main/java/net/techcable/tacospigot/ImmutableArrayTable.java
 new file mode 100644
-index 00000000..aa37b2f4
+index 000000000..aa37b2f45
 --- /dev/null
 +++ b/src/main/java/net/techcable/tacospigot/ImmutableArrayTable.java
 @@ -0,0 +1,36 @@
@@ -414,7 +411,7 @@ index 00000000..aa37b2f4
 +}
 diff --git a/src/main/java/net/techcable/tacospigot/SimpleMap.java b/src/main/java/net/techcable/tacospigot/SimpleMap.java
 new file mode 100644
-index 00000000..27559ee6
+index 000000000..27559ee67
 --- /dev/null
 +++ b/src/main/java/net/techcable/tacospigot/SimpleMap.java
 @@ -0,0 +1,10 @@
@@ -430,7 +427,7 @@ index 00000000..27559ee6
 +}
 diff --git a/src/main/java/net/techcable/tacospigot/SimpleTable.java b/src/main/java/net/techcable/tacospigot/SimpleTable.java
 new file mode 100644
-index 00000000..f76ad60b
+index 000000000..f76ad60b0
 --- /dev/null
 +++ b/src/main/java/net/techcable/tacospigot/SimpleTable.java
 @@ -0,0 +1,10 @@
@@ -445,7 +442,7 @@ index 00000000..f76ad60b
 +    public V get(@Nonnull R row, @Nonnull C column);
 +}
 diff --git a/src/main/java/net/techcable/tacospigot/TacoSpigotConfig.java b/src/main/java/net/techcable/tacospigot/TacoSpigotConfig.java
-index ce66b1c3..b7699d8c 100644
+index ce66b1c35..b7699d8c4 100644
 --- a/src/main/java/net/techcable/tacospigot/TacoSpigotConfig.java
 +++ b/src/main/java/net/techcable/tacospigot/TacoSpigotConfig.java
 @@ -102,4 +102,9 @@ public class TacoSpigotConfig {
@@ -460,7 +457,7 @@ index ce66b1c3..b7699d8c 100644
  }
 diff --git a/src/main/java/net/techcable/tacospigot/function/ObjIntBiFunction.java b/src/main/java/net/techcable/tacospigot/function/ObjIntBiFunction.java
 new file mode 100644
-index 00000000..87a50a3d
+index 000000000..87a50a3dc
 --- /dev/null
 +++ b/src/main/java/net/techcable/tacospigot/function/ObjIntBiFunction.java
 @@ -0,0 +1,6 @@
@@ -472,7 +469,7 @@ index 00000000..87a50a3d
 +}
 diff --git a/src/test/java/net/techcable/tacospigot/ImmutableArrayMapTest.java b/src/test/java/net/techcable/tacospigot/ImmutableArrayMapTest.java
 new file mode 100644
-index 00000000..179d0685
+index 000000000..179d06853
 --- /dev/null
 +++ b/src/test/java/net/techcable/tacospigot/ImmutableArrayMapTest.java
 @@ -0,0 +1,119 @@
@@ -596,5 +593,5 @@ index 00000000..179d0685
 +    }
 +}
 -- 
-2.16.2
+2.15.1.windows.2
 

--- a/Paper-Server-Patches/0009-Fix-incorrect-getNoDamageTicks.patch
+++ b/Paper-Server-Patches/0009-Fix-incorrect-getNoDamageTicks.patch
@@ -1,14 +1,14 @@
-From cecadb70b41a3005bdeba8613a8070d2451a9b41 Mon Sep 17 00:00:00 2001
+From 76e193214899bc51f844af2e427a3e1d30388962 Mon Sep 17 00:00:00 2001
 From: Jedediah Smith <jedediah@silencegreys.com>
 Date: Wed, 16 Mar 2016 22:03:58 -0400
 Subject: [PATCH] Fix incorrect getNoDamageTicks
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index fd47065c..195d2880 100644
+index 36a387137..cbf534cc7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1453,11 +1453,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1571,11 +1571,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public int getNoDamageTicks() {
@@ -26,5 +26,5 @@ index fd47065c..195d2880 100644
  
      @Override
 -- 
-2.17.0
+2.15.1.windows.2
 

--- a/Paper-Server-Patches/0010-Use-client-ticks-to-make-attack-speed-more-accurate.patch
+++ b/Paper-Server-Patches/0010-Use-client-ticks-to-make-attack-speed-more-accurate.patch
@@ -8,7 +8,7 @@ diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java
 index 0b51903e..5f4b81dd 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
-@@ -22,6 +22,8 @@ import org.bukkit.event.player.PlayerVelocityEvent;
+@@ -24,6 +24,8 @@ import org.bukkit.event.player.PlayerVelocityEvent;
  import org.bukkit.util.Vector;
  // CraftBukkit end
  
@@ -17,39 +17,40 @@ index 0b51903e..5f4b81dd 100644
  public abstract class EntityHuman extends EntityLiving {
  
      private static final DataWatcherObject<Float> a = DataWatcher.a(EntityHuman.class, DataWatcherRegistry.c);
-@@ -64,6 +66,9 @@ public abstract class EntityHuman extends EntityLiving {
-     private final ItemCooldown bW;
+@@ -68,6 +70,9 @@ public abstract class EntityHuman extends EntityLiving {
+     private final ItemCooldown ce;
      @Nullable
      public EntityFishingHook hookedFish;
 +
 +    public int clientTicksSinceLastAttack; // TacoSpigot
 +
+     // Paper start
      public boolean affectsSpawning = true;
- 
-     // CraftBukkit start
-@@ -1939,11 +1944,25 @@ public abstract class EntityHuman extends EntityLiving {
-     }
- 
-     public float n(float f) {
--        return MathHelper.a(((float) this.aE + f) / this.dr(), 0.0F, 1.0F);
+     // Paper end
+@@ -2067,12 +2072,26 @@ public abstract class EntityHuman extends EntityLiving {
+
+     public float getCooledAttackStrength(float adjustTicks) { return r(adjustTicks); } // Paper - OBFHELPER
+     public float r(float f) {
+-        return MathHelper.a(((float) this.aH + f) / this.dG(), 0.0F, 1.0F);
 +        // TacoSpigot start - use both client and server ticks
 +        if (betterPvp) {
 +            return MathHelper.a(
 +                (float) (Math.max(
-+                     this.aE,
++                     this.aH,
 +                     this.clientTicksSinceLastAttack
-+                ) + f) / this.dr(),
++                ) + f) / this.dG(),
 +                0.0F,
 +                1.0F
 +            );
 +        } else {
-+            return MathHelper.a(((float) this.aE + f) / this.dr(), 0.0F, 1.0F);
++            return MathHelper.a(((float) this.aH + f) / this.dG(), 0.0F, 1.0F);
 +        }
 +        // TacoSpigot end
      }
- 
-     public void ds() {
-         this.aE = 0;
+
+     public void resetCooldown() { dH(); } // Paper - OBFHELPER
+     public void dH() {
+         this.aH = 0;
 +        this.clientTicksSinceLastAttack = 0; // TacoSpigot
      }
  

--- a/Paper-Server-Patches/0010-Use-client-ticks-to-make-attack-speed-more-accurate.patch
+++ b/Paper-Server-Patches/0010-Use-client-ticks-to-make-attack-speed-more-accurate.patch
@@ -1,11 +1,11 @@
-From abbdcf27311db1f9d2ff46cb3f611f267be3ca48 Mon Sep 17 00:00:00 2001
+From 5172236989bcedc019ee72c7032390f68bb8fefe Mon Sep 17 00:00:00 2001
 From: Jedediah Smith <jedediah@silencegreys.com>
 Date: Tue, 19 Apr 2016 20:30:55 -0400
 Subject: [PATCH] Use client ticks to make attack speed more accurate
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index 0b51903e..5f4b81dd 100644
+index 4510ed805..0650fd0ac 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
 @@ -24,6 +24,8 @@ import org.bukkit.event.player.PlayerVelocityEvent;
@@ -28,7 +28,7 @@ index 0b51903e..5f4b81dd 100644
      public boolean affectsSpawning = true;
      // Paper end
 @@ -2067,12 +2072,26 @@ public abstract class EntityHuman extends EntityLiving {
-
+ 
      public float getCooledAttackStrength(float adjustTicks) { return r(adjustTicks); } // Paper - OBFHELPER
      public float r(float f) {
 -        return MathHelper.a(((float) this.aH + f) / this.dG(), 0.0F, 1.0F);
@@ -47,7 +47,7 @@ index 0b51903e..5f4b81dd 100644
 +        }
 +        // TacoSpigot end
      }
-
+ 
      public void resetCooldown() { dH(); } // Paper - OBFHELPER
      public void dH() {
          this.aH = 0;
@@ -56,10 +56,10 @@ index 0b51903e..5f4b81dd 100644
  
      public ItemCooldown getCooldownTracker() {
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index a5faa6a0..2ec63775 100644
+index a8a6e236e..f1a0bb2a1 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -510,6 +510,8 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
+@@ -872,6 +872,8 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
                      this.syncPosition();
                  }
  
@@ -69,7 +69,7 @@ index a5faa6a0..2ec63775 100644
                      if (this.e - this.A > 20) {
                          this.A = this.e;
 diff --git a/src/main/java/net/techcable/tacospigot/TacoSpigotConfig.java b/src/main/java/net/techcable/tacospigot/TacoSpigotConfig.java
-index b7699d8c..22c6009a 100644
+index b7699d8c4..22c6009ab 100644
 --- a/src/main/java/net/techcable/tacospigot/TacoSpigotConfig.java
 +++ b/src/main/java/net/techcable/tacospigot/TacoSpigotConfig.java
 @@ -107,4 +107,9 @@ public class TacoSpigotConfig {
@@ -83,5 +83,5 @@ index b7699d8c..22c6009a 100644
 +    }
  }
 -- 
-2.17.0
+2.15.1.windows.2
 

--- a/Paper-Server-Patches/0011-Use-arrays-for-the-DataWatcher-and-optionaly-disable.patch
+++ b/Paper-Server-Patches/0011-Use-arrays-for-the-DataWatcher-and-optionaly-disable.patch
@@ -38,24 +38,6 @@ index 820c15278..ac728575b 100644
      private boolean f = true;
      private boolean g;
  
-@@ -89,7 +96,7 @@ public class DataWatcher {
-         DataWatcher.Item datawatcher_item = new DataWatcher.Item(datawatcherobject, t0);
- 
-         this.e.writeLock().lock();
--        this.d.put(Integer.valueOf(datawatcherobject.a()), datawatcher_item);
-+        this.d.put(datawatcherobject.a(), datawatcher_item); // TacoSpigot - primitives
-         this.f = false;
-         this.e.writeLock().unlock();
-     }
-@@ -100,7 +107,7 @@ public class DataWatcher {
-         DataWatcher.Item datawatcher_item;
- 
-         try {
--            datawatcher_item = (DataWatcher.Item) this.d.get(Integer.valueOf(datawatcherobject.a()));
-+            datawatcher_item = (DataWatcher.Item) this.d.get(datawatcherobject.a()); // TacoSpigot - use primitives
-         } catch (Throwable throwable) {
-             CrashReport crashreport = CrashReport.a(throwable, "Getting synched entity data");
-             CrashReportSystemDetails crashreportsystemdetails = crashreport.a("Synched entity data");
 diff --git a/src/main/java/net/techcable/tacospigot/ArrayMap.java b/src/main/java/net/techcable/tacospigot/ArrayMap.java
 new file mode 100644
 index 000000000..36c9fd252

--- a/Paper-Server-Patches/0012-Better-version-checking.patch
+++ b/Paper-Server-Patches/0012-Better-version-checking.patch
@@ -22,7 +22,7 @@ index 9f27e129..9439d7c5 100644
  
  public class Main {
      public static boolean useJline = true;
-@@ -211,6 +217,8 @@ public class Main {
+@@ -219,6 +225,8 @@ public class Main {
                      System.setProperty(TerminalConsoleAppender.JLINE_OVERRIDE_PROPERTY, "false"); // Paper
                  }
  
@@ -31,7 +31,7 @@ index 9f27e129..9439d7c5 100644
                  if (Main.class.getPackage().getImplementationVendor() != null && System.getProperty("IReallyKnowWhatIAmDoingISwear") == null) {
                      Date buildDate = new SimpleDateFormat("yyyyMMdd-HHmm").parse(Main.class.getPackage().getImplementationVendor());
  
-@@ -225,6 +233,42 @@ public class Main {
+@@ -233,6 +241,42 @@ public class Main {
                          // Paper End
                      }
                  }
@@ -72,8 +72,8 @@ index 9f27e129..9439d7c5 100644
 +                }
 +                // TacoSpigot end
  
-                 net.techcable.tacospigot.TacoSpigotConfig.init((File) options.valueOf("taco-settings")); // TacoSpigot - initalize before library loading so we can access while loading
-                 System.out.println("Loading libraries, please wait...");
+                 // Paper start - Log Java and OS versioning to help with debugging plugin issues
+                 java.lang.management.RuntimeMXBean runtimeMX = java.lang.management.ManagementFactory.getRuntimeMXBean();
 -- 
 2.14.2
 

--- a/scripts/applyPatches.sh
+++ b/scripts/applyPatches.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+(
+PS1="$"
+basedir="$(pwd -P)"
+workdir="$basedir/Paper/work"
+minecraftversion=$(cat "$workdir/BuildData/info.json"  | grep minecraftVersion | cut -d '"' -f 4)
+gitcmd="git -c commit.gpgsign=false"
+applycmd="$gitcmd am --3way --ignore-whitespace"
+# Windows detection to workaround ARG_MAX limitation
+windows="$([[ "$OSTYPE" == "cygwin" || "$OSTYPE" == "msys" ]] && echo "true" || echo "false")"
+
+echo "Rebuilding Forked projects.... "
+
+function applyPatch {
+    what=$1
+    what_name=$(basename "$what")
+    target=$2
+    branch=$3
+
+    cd "$basedir/$what"
+    ${gitcmd} fetch
+    ${gitcmd} branch -f upstream "$branch" >/dev/null
+
+    cd "$basedir"
+    if [[ ! -d  "$basedir/$target" ]]; then
+        ${gitcmd} clone "$what" "$target"
+    fi
+    cd "$basedir/$target"
+
+    echo "Resetting $target to $what_name..."
+    ${gitcmd} remote rm upstream > /dev/null 2>&1
+    ${gitcmd} remote add upstream ../${what} >/dev/null 2>&1
+    ${gitcmd} checkout master 2>/dev/null || ${gitcmd} checkout -b master
+    ${gitcmd} fetch upstream >/dev/null 2>&1
+    ${gitcmd} reset --hard upstream/upstream
+
+    echo "  Applying patches to $target..."
+
+    statusfile=".git/patch-apply-failed"
+    rm -f ${statusfile}
+    ${gitcmd} am --abort >/dev/null 2>&1
+
+    # Special case Windows handling because of ARG_MAX constraint
+    if [[ ${windows} == "true" ]]; then
+        echo "  Using workaround for Windows ARG_MAX constraint"
+        find "$basedir/${what_name}-Patches/"*.patch -print0 | xargs -0 ${applycmd}
+    else
+        ${applycmd} "$basedir/${what_name}-Patches/"*.patch
+    fi
+
+    if [[ "$?" != "0" ]]; then
+        echo 1 > "$statusfile"
+        echo "  Something did not apply cleanly to $target."
+        echo "  Please review above details and finish the apply then"
+        echo "  save the changes with rebuildPatches.sh"
+
+        # On Windows, finishing the patch apply will only fix the latest patch
+        # users will need to rebuild from that point and then re-run the patch
+        # process to continue
+        if [[ ${windows} == "true" ]]; then
+            echo ""
+            echo "  Because you're on Windows you'll need to finish the AM,"
+            echo "  rebuild all patches, and then re-run the patch apply again."
+            echo "  Consider using the scripts with Windows Subsystem for Linux."
+        fi
+
+        exit 1
+    else
+        rm -f "$statusfile"
+        echo "  Patches applied cleanly to $target"
+    fi
+}
+
+# Move into spigot dir
+cd "$workdir/Spigot"
+basedir=$(pwd)
+# Apply Spigot
+(
+    applyPatch ../Bukkit Spigot-API HEAD &&
+    applyPatch ../CraftBukkit Spigot-Server patched
+) || (
+    echo "Failed to apply Spigot Patches"
+    exit 1
+) || exit 1
+# Move out of Spigot
+basedir=$(dirname $(dirname ${basedir}))
+cd "$basedir"
+echo "Importing Paper MC Dev"
+
+./scripts/importmcdev.sh "$basedir" || exit 1
+# Apply paper
+(
+    applyPatch work/Spigot/Spigot-API Paper-API HEAD &&
+    applyPatch work/Spigot/Spigot-Server Paper-Server HEAD
+) || (
+    echo "Failed to apply Paper Patches"
+    exit 1
+) || exit 1
+
+# Move out of paper
+cd $(dirname ${basedir})
+
+echo "Importing TacoSpigot mc-dev"
+./scripts/importmcdev.sh "$basedir" || exit 1
+basedir=$(dirname ${basedir})
+
+# Apply TacoSpigot
+(
+    applyPatch Paper/Paper-API TacoSpigot-API HEAD &&
+    applyPatch Paper/Paper-Server TacoSpigot-Server HEAD
+) || (
+    echo "Failed to apply Taco Patches"
+    exit 1
+) || exit 1
+) || exit 1

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+(
+set -e
+basedir="$(cd "$1" && pwd -P)/Paper"
+gitcmd="git -c commit.gpgsign=false"
+
+(${gitcmd} submodule update --recursive --init && ./scripts/remap.sh "$basedir" && ./scripts/decompile.sh "$basedir" && ./scripts/init.sh "$basedir" && ./scripts/applyPatches.sh "$basedir") || (
+    echo "Failed to build Taco"
+    exit 1
+) || exit 1
+mvn clean install && ./scripts/paperclip.sh "$basedir"
+) || exit 1

--- a/scripts/decompile.sh
+++ b/scripts/decompile.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+
+pushd Paper # TacoSpigot
+
+(
+set -e
+PS1="$"
+basedir="$(cd "$1" && pwd -P)"
+workdir="$basedir/work"
+minecraftversion=$(cat work/BuildData/info.json | grep minecraftVersion | cut -d '"' -f 4)
+windows="$([[ "$OSTYPE" == "cygwin" || "$OSTYPE" == "msys" ]] && echo "true" || echo "false")"
+decompiledir="$workdir/Minecraft/$minecraftversion"
+spigotdecompiledir="$decompiledir/spigot"
+forgedecompiledir="$decompiledir/forge"
+forgeflowerversion="1.5.380.19"
+forgeflowerurl="http://files.minecraftforge.net/maven/net/minecraftforge/forgeflower/$forgeflowerversion/forgeflower-$forgeflowerversion.jar"
+# temp use patched version
+forgeflowerurl="https://zachbr.keybase.pub/paper/forgeflower-patched/forgeflower-1.5.380.19.jar?dl=1"
+forgeflowerbin="$workdir/ForgeFlower/$forgeflowerversion.jar"
+# TODO: Make this better? We don't need spigot compat for this stage
+forgefloweroptions="-dgs=1 -hdc=0 -asc=1 -udv=1 -jvn=1"
+forgeflowercachefile="$decompiledir/forgeflowercache"
+forgeflowercachevalue="$forgeflowerurl - $forgeflowerversion - $forgefloweroptions";
+classdir="$decompiledir/classes"
+versionjson="$workdir/Minecraft/$minecraftversion/$minecraftversion.json"
+
+if [[ ! -f "$versionjson" ]]; then
+    echo "Downloading $minecraftversion JSON Data"
+    verescaped=$(echo ${minecraftversion} | sed 's/\./\\./g')
+    verentry=$(curl -s "https://launchermeta.mojang.com/mc/game/version_manifest.json" | grep -oE "{\"id\": \"${verescaped}\".*${verescaped}\.json")
+    jsonurl=$(echo ${verentry} | grep -oE https:\/\/.*\.json)
+    curl -o "$versionjson" "$jsonurl"
+    echo "$versionjson - $jsonurl"
+fi
+
+function downloadLibraries {
+    group=$1
+    groupesc=$(echo ${group} | sed 's/\./\\./g')
+    grouppath=$(echo ${group} | sed 's/\./\//g')
+    libdir="$decompiledir/libraries/${group}/"
+    mkdir -p "$libdir"
+    shift
+    for lib in "$@"
+    do
+        jar="$libdir/${lib}-sources.jar"
+        destlib="$libdir/${lib}"
+        if [[ ! -f "$jar" ]]; then
+            libesc=$(echo ${lib} | sed 's/\./\\]./g')
+            ver=$(grep -oE "${groupesc}:${libesc}:[0-9\.]+" "$versionjson" | sed "s/${groupesc}:${libesc}://g")
+            echo "Downloading ${group}:${lib}:${ver} Sources"
+            curl -s -o "$jar" "https://libraries.minecraft.net/${grouppath}/${lib}/${ver}/${lib}-${ver}-sources.jar"
+            set +e
+            grep "<html>" "$jar" && grep -oE "<title>.*?</title>" "$jar" && rm "$jar" && echo "Failed to download $jar" && exit 1
+            set -e
+        fi
+
+        if [[ ! -d "$destlib/$grouppath" ]]; then
+            echo "Extracting $group:$lib Sources"
+            mkdir -p "$destlib"
+            (cd "$destlib" && jar xf "$jar")
+        fi
+    done
+}
+
+downloadLibraries "com.mojang" datafixerupper authlib brigadier
+
+# prep folders
+mkdir -p "$workdir/ForgeFlower"
+mkdir -p "$spigotdecompiledir"
+mkdir -p "$forgedecompiledir"
+
+echo "Extracting NMS classes..."
+if [[ ! -d "$classdir" ]]; then
+    mkdir -p "$classdir"
+    cd "$classdir"
+    set +e
+    jar xf "$decompiledir/$minecraftversion-mapped.jar" net/minecraft/server
+    if [[ "$?" != "0" ]]; then
+        cd "$basedir"
+        echo "Failed to extract NMS classes."
+        exit 1
+    fi
+    set -e
+fi
+
+if [[ -d "$decompiledir/net" ]]; then
+    cp -r "$decompiledir/net" "$spigotdecompiledir/"
+fi
+
+if [[ ! -d "$spigotdecompiledir/net" ]]; then
+    echo "Decompiling classes (stage 2)..."
+    cd "$basedir"
+    set +e
+    java -jar "$workdir/BuildData/bin/fernflower.jar" -dgs=1 -hdc=0 -asc=1 -udv=0 "$classdir" "$spigotdecompiledir"
+    if [[ "$?" != "0" ]]; then
+        rm -rf "$spigotdecompiledir/net"
+        echo "Failed to decompile classes."
+        exit 1
+    fi
+fi
+
+# set a symlink to current
+currentlink="$workdir/Minecraft/current"
+if ([[ ! -e "$currentlink" ]] || [[ -L "$currentlink" ]]) && [[ "$windows" == "false" ]]; then
+	set +e
+	echo "Pointing $currentlink to $minecraftversion"
+	rm -rf "$currentlink" || true
+	ln -sfn "$minecraftversion" "$currentlink" || echo "Failed to set current symlink"
+fi
+)
+
+popd # TacoSpigot

--- a/scripts/decompile.sh
+++ b/scripts/decompile.sh
@@ -91,7 +91,7 @@ if [[ ! -d "$spigotdecompiledir/net" ]]; then
     echo "Decompiling classes (stage 2)..."
     cd "$basedir"
     set +e
-    java -jar "$workdir/BuildData/bin/fernflower.jar" -dgs=1 -hdc=0 -asc=1 -udv=0 "$classdir" "$spigotdecompiledir"
+    java -jar "$workdir/BuildData/bin/fernflower.jar" -dgs=1 -hdc=0 -asc=1 -udv=0 -rsy=1 "$classdir" "$spigotdecompiledir"
     if [[ "$?" != "0" ]]; then
         rm -rf "$spigotdecompiledir/net"
         echo "Failed to decompile classes."

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+gitcmd="git -c commit.gpgsign=false"
+
+color() {
+    if [[ $2 ]]; then
+            echo -e "\e[$1;$2m"
+    else
+            echo -e "\e[$1m"
+    fi
+}
+colorend() {
+    echo -e "\e[m"
+}
+
+paperstash() {
+    STASHED=$(${gitcmd} stash  2>/dev/null|| return 0) # errors are ok
+}
+
+paperunstash() {
+    if [[ "$STASHED" != "No local changes to save" ]] ; then
+        ${gitcmd} stash pop 2>/dev/null|| return 0 # errors are ok
+    fi
+}

--- a/scripts/importmcdev.sh
+++ b/scripts/importmcdev.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+(
+set -e
+nms="net/minecraft/server"
+export MODLOG=""
+PS1="$"
+basedir="$(cd "$1" && pwd -P)"
+source "$basedir/scripts/functions.sh"
+gitcmd="git -c commit.gpgsign=false"
+
+workdir="$basedir/work"
+minecraftversion=$(cat "$workdir/BuildData/info.json"  | grep minecraftVersion | cut -d '"' -f 4)
+decompiledir="$workdir/Minecraft/$minecraftversion/forge"
+# replace for now
+decompiledir="$workdir/Minecraft/$minecraftversion/spigot"
+
+export importedmcdev=""
+function import {
+	export importedmcdev="$importedmcdev $1"
+	file="${1}.java"
+    target="$basedir/Paper-Server/src/main/java/$nms/$file"
+    base="$decompiledir/$nms/$file"
+
+	if [[ ! -f "$target" ]]; then
+		export MODLOG="$MODLOG  Imported $file from mc-dev\n";
+		echo "Copying $base to $target"
+		cp "$base" "$target" || exit 1
+	else
+	    echo "UN-NEEDED IMPORT: $file"
+	fi
+}
+
+function importLibrary {
+    group=$1
+    lib=$2
+    prefix=$3
+    shift 3
+    for file in "$@"; do
+        file="$prefix/$file"
+        target="$workdir/Spigot/Spigot-Server/src/main/java/${file}"
+        targetdir=$(dirname "$target")
+        mkdir -p "${targetdir}"
+        base="$workdir/Minecraft/$minecraftversion/libraries/${group}/${lib}/$file"
+        if [[ ! -f "$base" ]]; then
+            echo "Missing $base"
+            exit 1
+        fi
+        export MODLOG="$MODLOG  Imported $file from $lib\n";
+        cp "$base" "$target" || exit 1
+    done
+}
+
+(
+	cd Paper/Paper-Server/
+	lastlog=$(${gitcmd} log -1 --oneline)
+	if [[ "$lastlog" = *"mc-dev Imports"* ]]; then
+		${gitcmd} reset --hard HEAD^
+	fi
+)
+
+files=$(cat "Paper-Server-Patches/"* | grep "+++ b/src/main/java/net/minecraft/server/" | sort | uniq | sed 's/\+\+\+ b\/src\/main\/java\/net\/minecraft\/server\///g' | sed 's/.java//g')
+nonnms=$(grep -R "new file mode" -B 1 "Paper-Server-Patches/" | grep -v "new file mode" | grep -oE "net\/minecraft\/server\/.*.java" | grep -oE "[A-Za-z]+?.java$" --color=none | sed 's/.java//g')
+function containsElement {
+	local e
+	for e in "${@:2}"; do
+		[[ "$e" == "$1" ]] && return 0;
+	done
+	return 1
+}
+set +e
+for f in ${files}; do
+	containsElement "$f" ${nonnms[@]}
+	if [[ "$?" == "1" ]]; then
+		if [[ ! -f "$basedir/Paper-Server/src/main/java/net/minecraft/server/$f.java" ]]; then
+			if [[ ! -f "$decompiledir/$nms/$f.java" ]]; then
+				echo "$(color 1 31) ERROR!!! Missing NMS$(color 1 34) $f $(colorend)";
+			else
+				import ${f}
+			fi
+		fi
+	fi
+done
+
+set -e
+
+(
+	cd Paper/Paper-Server/
+	${gitcmd} add src -A
+
+	# Do not commit if there's no change
+	if ! ${gitcmd} diff-index --cached --quiet HEAD --ignore-submodules --
+    then
+	    echo -e "mc-dev Imports\n\n$MODLOG" | ${gitcmd} commit src -F -
+	fi
+)
+)

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -19,7 +19,7 @@ if [[ "x$patch" == "x" ]]; then
 fi
 
 echo "Applying CraftBukkit patches to NMS..."
-cd "$basedir/work/CraftBukkit"
+cd "$workdir/CraftBukkit"
 ${gitcmd} checkout -B patched HEAD >/dev/null 2>&1
 rm -rf "$cb"
 mkdir -p "$cb"

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+pushd Paper # TacoSpigot
+
+(
+set -e
+PS1="$"
+basedir="$(cd "$1" && pwd -P)"
+workdir="$basedir/work"
+minecraftversion=$(cat work/BuildData/info.json | grep minecraftVersion | cut -d '"' -f 4)
+spigotdecompiledir="$workdir/Minecraft/$minecraftversion/spigot"
+nms="$spigotdecompiledir/net/minecraft/server"
+cb="src/main/java/net/minecraft/server"
+gitcmd="git -c commit.gpgsign=false"
+
+patch=$(which patch 2>/dev/null)
+if [[ "x$patch" == "x" ]]; then
+    patch=${basedir}/hctap.exe
+fi
+
+echo "Applying CraftBukkit patches to NMS..."
+cd "$basedir/work/CraftBukkit"
+${gitcmd} checkout -B patched HEAD >/dev/null 2>&1
+rm -rf "$cb"
+mkdir -p "$cb"
+for file in $(ls nms-patches)
+do
+    patchFile="nms-patches/$file"
+    file="$(echo "$file" | cut -d. -f1).java"
+    cp "$nms/$file" "$cb/$file"
+done
+${gitcmd} add src
+${gitcmd} commit -m "Minecraft $ $(date)" --author="Auto <auto@mated.null>"
+
+for file in $(ls nms-patches)
+do
+    patchFile="nms-patches/$file"
+    file="$(echo "$file" | cut -d. -f1).java"
+
+    echo "Patching $file < $patchFile"
+    set +e
+    sed -i 's/\r//' "$nms/$file" > /dev/null
+    set -e
+
+    "$patch" -s -d src/main/java/ "net/minecraft/server/$file" < "$patchFile"
+done
+
+${gitcmd} add src >/dev/null 2>&1
+${gitcmd} commit -m "CraftBukkit $ $(date)" --author="Auto <auto@mated.null>" >/dev/null 2>&1
+${gitcmd} checkout -f HEAD~2 >/dev/null 2>&1
+
+popd # TacoSpigot
+)

--- a/scripts/paperclip.sh
+++ b/scripts/paperclip.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+(
+set -e
+basedir="$(cd "$1" && pwd -P)"
+workdir="$basedir/work"
+mcver=$(cat "$workdir/BuildData/info.json" | grep minecraftVersion | cut -d '"' -f 4)
+paperjar="$basedir/Paper-Server/target/paper-$mcver.jar"
+vanillajar="$workdir/Minecraft/$mcver/$mcver.jar"
+
+(
+    cd "$workdir/Paperclip"
+    mvn clean package "-Dmcver=$mcver" "-Dpaperjar=$paperjar" "-Dvanillajar=$vanillajar"
+)
+cp "$workdir/Paperclip/assembly/target/paperclip-${mcver}.jar" "$basedir/paperclip.jar"
+
+echo ""
+echo ""
+echo ""
+echo "Build success!"
+echo "Copied final jar to $(cd "$basedir" && pwd -P)/paperclip.jar"
+) || exit 1

--- a/scripts/paperclip.sh
+++ b/scripts/paperclip.sh
@@ -5,7 +5,7 @@ set -e
 basedir="$(cd "$1" && pwd -P)"
 workdir="$basedir/work"
 mcver=$(cat "$workdir/BuildData/info.json" | grep minecraftVersion | cut -d '"' -f 4)
-paperjar="$basedir/Paper-Server/target/paper-$mcver.jar"
+paperjar="$basedir/../TacoSpigot-Server/target/paper-$mcver.jar"
 vanillajar="$workdir/Minecraft/$mcver/$mcver.jar"
 
 (

--- a/scripts/remap.sh
+++ b/scripts/remap.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+pushd Paper # TacoSpigot
+
+(
+set -e
+PS1="$"
+basedir="$(cd "$1" && pwd -P)"
+workdir="$basedir/work"
+minecraftversion=$(cat work/BuildData/info.json | grep minecraftVersion | cut -d '"' -f 4)
+minecrafthash=$(cat work/BuildData/info.json | grep minecraftHash | cut -d '"' -f 4)
+minecraftserverurl=$(cat "${workdir}/BuildData/info.json" | grep serverUrl | cut -d '"' -f 4)
+accesstransforms=work/BuildData/mappings/$(cat work/BuildData/info.json | grep accessTransforms | cut -d '"' -f 4)
+classmappings=work/BuildData/mappings/$(cat work/BuildData/info.json | grep classMappings | cut -d '"' -f 4)
+membermappings=work/BuildData/mappings/$(cat work/BuildData/info.json | grep memberMappings | cut -d '"' -f 4)
+packagemappings=work/BuildData/mappings/$(cat work/BuildData/info.json | grep packageMappings | cut -d '"' -f 4)
+decompiledir="$workdir/Minecraft/$minecraftversion"
+jarpath="$decompiledir/$minecraftversion"
+mkdir -p "$decompiledir"
+
+echo "Downloading unmapped vanilla jar..."
+if [[ ! -f  "$jarpath.jar" ]]; then
+    curl -s -o "$jarpath.jar" "$minecraftserverurl"
+    if [[ "$?" != "0" ]]; then
+        echo "Failed to download the vanilla server jar. Check connectivity or try again later."
+        exit 1
+    fi
+fi
+
+# OS X & FreeBSD don't have md5sum, just md5 -r
+command -v md5sum >/dev/null 2>&1 || {
+    command -v md5 >/dev/null 2>&1 && {
+        shopt -s expand_aliases
+        alias md5sum='md5 -r'
+        echo "md5sum command not found, using an alias instead"
+    } || {
+        echo >&2 "No md5sum or md5 command found"
+        exit 1
+    }
+}
+
+checksum=$(md5sum "$jarpath.jar" | cut -d ' ' -f 1)
+if [[ "$checksum" != "$minecrafthash" ]]; then
+    echo "The MD5 checksum of the downloaded server jar does not match the work/BuildData hash."
+    exit 1
+fi
+
+echo "Applying class mappings..."
+if [[ ! -f "$jarpath-cl.jar" ]]; then
+    java -jar work/BuildData/bin/SpecialSource-2.jar map --only . --only net/minecraft --auto-lvt BASIC --auto-synth -i "$jarpath.jar" -m "$classmappings" -o "$jarpath-cl.jar" 1>/dev/null
+    if [[ "$?" != "0" ]]; then
+        echo "Failed to apply class mappings."
+        exit 1
+    fi
+fi
+
+echo "Applying member mappings..."
+if [[ ! -f "$jarpath-m.jar" ]]; then
+    java -jar work/BuildData/bin/SpecialSource-2.jar map --only . --only net/minecraft -i "$jarpath-cl.jar" -m "$membermappings" -o "$jarpath-m.jar" 1>/dev/null
+    if [[ "$?" != "0" ]]; then
+        echo "Failed to apply member mappings."
+        exit 1
+    fi
+fi
+
+echo "Creating remapped jar..."
+if [[ ! -f "$jarpath-mapped.jar" ]]; then
+    java -jar work/BuildData/bin/SpecialSource.jar --only . --only net/minecraft --only com/mojang/brigadier -i "$jarpath-m.jar" --access-transformer "$accesstransforms" -m "$packagemappings" -o "$jarpath-mapped.jar" 1>/dev/null
+    if [[ "$?" != "0" ]]; then
+        echo "Failed to create remapped jar."
+        exit 1
+    fi
+fi
+
+echo "Installing remapped jar..."
+cd work/CraftBukkit # Need to be in a directory with a valid POM at the time of install.
+mvn install:install-file -q -Dfile="$jarpath-mapped.jar" -Dpackaging=jar -DgroupId=org.spigotmc -DartifactId=minecraft-server -Dversion="$minecraftversion-SNAPSHOT"
+if [[ "$?" != "0" ]]; then
+    echo "Failed to install remapped jar."
+    exit 1
+fi
+)
+
+popd # TacoSpigot


### PR DESCRIPTION
I have updated TacoSpigot to support 1.13.2.

There are only 2 things to fix before merging :
- The new scripts, copied and adapted from Paper with bug fixes and improvements (in the scripts folder) are using the Paper/work directory instead of /work (and don't have `chmod 755`, thanks windows)
- The patch 0008-Use-arrays-for-blockstates.patch is not complete, since the whole BlockStateList class changed a lot, and I don't really know what to do about it. The class isn't the same as before at all.
