### PR TITLE
Remove references to nonexistent scripts in remap-nms.sh

### DIFF
--- a/remap-nms.sh
+++ b/remap-nms.sh
@@ -1,9 +1,6 @@
 #!/bin/bash -e
 cd "$(dirname "$0")"
 
-. util.sh
-. version.sh
-
 mkdir -p $(dirname ${NMS_JAR}) # Make the cache dir
 downloadfile "${NMS_JAR}" "${NMS_URL}" "${NMS_MD5}"
 


### PR DESCRIPTION
Removes references in `remap-nms.sh` to two scripts that don't exist and are causing it to fail.