### PR TITLE
Use correct BuildData version

### DIFF
--- a/prepare-build.sh
+++ b/prepare-build.sh
@@ -1,8 +1,21 @@
 #!/bin/bash
 
 git submodule update --recursive --init && \
-cd Paper/work/BuildData && \
+# echo "Updating Paper..." && \
+cd Paper && \
+# git checkout ver/1.12.2 && \
+echo "Updating BuildData..." && \
+cd work/BuildData && \
 git checkout 8eaf2804afba334ca73c3e190cf092064c631692 && \
+echo "Updating Bukkit..." && \
+cd ../Bukkit && \
+git checkout 987016eada9da174c27b90126759a73eb21bdf76 && \
+echo "Updating CraftBukkit..." && \
+cd ../CraftBukkit && \
+git checkout version/1.13.2 && \
+# echo "Updating Paperclip..." && \
+# cd ../Paperclip && \
+# git checkout ver/1.12.2 && \
 cd ../../.. && \
 ./remap.sh && ./decompile.sh && ./init.sh && ./applyPatches.sh
 

--- a/prepare-build.sh
+++ b/prepare-build.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-git submodule update --recursive --init && ./remap.sh && ./decompile.sh && ./init.sh && ./applyPatches.sh
+git submodule update --recursive --init && \
+cd Paper/work/BuildData && \
+git checkout 8eaf2804afba334ca73c3e190cf092064c631692 && \
+cd ../../.. && \
+./remap.sh && ./decompile.sh && ./init.sh && ./applyPatches.sh
 
 # Generate paperclip jar in this stage
 mkdir -p work/Paperclip

--- a/remap.sh
+++ b/remap.sh
@@ -32,7 +32,7 @@ fi
 
 checksum=$(md5sum "$jarpath.jar" | cut -d ' ' -f 1)
 if [ "$checksum" != "$minecrafthash" ]; then
-    echo "The MD5 checksum of the downloaded server jar does not match the work/BuildData hash."
+    echo "The MD5 checksum of the downloaded server jar ($checksum) does not match the work/BuildData hash ($minecrafthash)."
     exit 1
 fi
 


### PR DESCRIPTION
The build is currently broken because a submodule, BuildData, is being updated to HEAD, which is now the 1.14 version. This PR fixes that issue by checking out the last 1.13.2 version of BuildData (https://hub.spigotmc.org/stash/projects/SPIGOT/repos/builddata/commits/8eaf2804afba334ca73c3e190cf092064c631692) after updating submodules.